### PR TITLE
fix: context menu multi-select deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^1.2.24",
-        "@blockly/dev-tools": "^3.1.8",
-        "blockly": "^8.0.3"
+        "@blockly/dev-scripts": "^1.2.26",
+        "@blockly/dev-tools": "^4.0.2",
+        "blockly": "^8.0.4"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^8.0.3"
+        "blockly": "^8.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1726,9 +1726,9 @@
       }
     },
     "node_modules/@blockly/block-test": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.15.tgz",
-      "integrity": "sha512-S9A763PH1ILv/OnXHJtwdDX0obHupXlh2ccai4/6ddaNt1cm6ePBjm7t2iNNAGT3vlgum/GpEdG02LtwNCfohA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.17.tgz",
+      "integrity": "sha512-nOnNV2vOEsWrGgn9LerSKZpv+nF9Og3IKJO+pUtAfu8XDDzu0C6Veq1bsUEGfXDpJCaoexwn8NiZtqJwl2F7DQ==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
@@ -1738,16 +1738,16 @@
       }
     },
     "node_modules/@blockly/dev-scripts": {
-      "version": "1.2.24",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-1.2.24.tgz",
-      "integrity": "sha512-hKjZjfcjUqRefIdusQwCxeDAWEFdFjrLzQQauJwh2ATfct0rqBjciCK7veytnrdOoBXzYN8n8gaDOsiL2TB39g==",
+      "version": "1.2.26",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-1.2.26.tgz",
+      "integrity": "sha512-2d+vVu5mnC7bfuIoS9amnvrmdBMewwe3z0EJ/jDACWNNXp7UwDn+yI162x+hyhmkFmvqvJGwKmKKhAiWUqt+iA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.8.3",
         "@babel/core": "^7.8.6",
         "@babel/preset-env": "^7.8.6",
         "@babel/preset-typescript": "^7.9.0",
-        "@blockly/eslint-config": "^2.1.16",
+        "@blockly/eslint-config": "^2.1.17",
         "babel-loader": "^8.0.6",
         "chalk": "^4.0.0",
         "eslint": "^7.15.0",
@@ -1767,7 +1767,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "typescript": "^3.2.1"
+        "typescript": "^4.3.2"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1776,16 +1776,16 @@
       }
     },
     "node_modules/@blockly/dev-tools": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-3.1.8.tgz",
-      "integrity": "sha512-NspvkxClFlBsYe9mxfi51QuVFYtUVcKtG9OmtxEoapk1G6K1JDp3jtwUfNd3U2UjMmFHZMP9OaJC5nQQBye3hw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-4.0.2.tgz",
+      "integrity": "sha512-Vb26ATIGRR/qm3D09OOZqghgaabkzT77OZOzvvAp5UY302a/GT15bTKsdZ1jtK/sGA4ZuBvC+3q5E+sJG9cDTQ==",
       "dev": true,
       "dependencies": {
-        "@blockly/block-test": "^2.0.14",
-        "@blockly/theme-dark": "^3.0.13",
-        "@blockly/theme-deuteranopia": "^2.0.13",
-        "@blockly/theme-highcontrast": "^2.0.13",
-        "@blockly/theme-tritanopia": "^2.0.13",
+        "@blockly/block-test": "^2.0.17",
+        "@blockly/theme-dark": "^3.0.16",
+        "@blockly/theme-deuteranopia": "^2.0.16",
+        "@blockly/theme-highcontrast": "^2.0.16",
+        "@blockly/theme-tritanopia": "^2.0.16",
         "chai": "^4.2.0",
         "dat.gui": "^0.7.7",
         "lodash.assign": "^4.2.0",
@@ -1797,13 +1797,13 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": ">=7 <9"
+        "blockly": ">=8 <9"
       }
     },
     "node_modules/@blockly/eslint-config": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.16.tgz",
-      "integrity": "sha512-OTvY4gPM/FzqCk11fBDN2Kr7IO/HUpuw5PjxeHQQXUbUL2ODS8EMlQOJ0x22XTZ+j3TjENHBQ9bnEIMZs6efgg==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.17.tgz",
+      "integrity": "sha512-hNDj3nXMfKNzph8rG6sbRKU4ZiHcgt/wW7jP9NhzADN29TfpozaupDOD7BdhW98CFCLTD1HJtFdO3sHyP0bfOg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.0.0",
@@ -1820,9 +1820,9 @@
       }
     },
     "node_modules/@blockly/theme-dark": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-3.0.14.tgz",
-      "integrity": "sha512-narn7BtQF/0lV0vzvKbtC8UMPyqHHSdNOEWNgK+RqccpcKKRaLtl6WsGd8vMr+AyFwUmF0L+0X5lFLn0qw9EFw==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-3.0.16.tgz",
+      "integrity": "sha512-a76DRJNcJ7TgCLkHevICUzhkMRYYdPpcg24OPuKMEnzrSUblT+VHuuElVLBDNs24wR/SRCnXC3qAiXwYi/bzdg==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
@@ -1832,9 +1832,9 @@
       }
     },
     "node_modules/@blockly/theme-deuteranopia": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-2.0.14.tgz",
-      "integrity": "sha512-qnTQS/BlIjTXyTaGjpqHoblZ3cJALytFWZ6A4acnJ13L/ExTe78kmyP64xuI3cPkkvLe9qtyEK+U4JZqqXAnEA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-2.0.16.tgz",
+      "integrity": "sha512-8lgh5AGIfANugVO9EQJ5woy6JZ8BUvlxxky0iRab6nIVDAlA6m4k+HiqKUbEThBh69vlvMObwZW2DNcxVpcVrA==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
@@ -1844,9 +1844,9 @@
       }
     },
     "node_modules/@blockly/theme-highcontrast": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-2.0.14.tgz",
-      "integrity": "sha512-zXV/ONIgKJZO3hGOIAgfvNZ1pRdwxk97w+n/kz1v/6n3xDyJUrl7CgXhO+WQOpePi6UTPUEdcoVGZAzd8u6AHg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-2.0.16.tgz",
+      "integrity": "sha512-3ffHBxmdQea7NcsWBNCgGctW6fNeHHIK5S9PQ4994p1i4FLID9cQCrIRdCvodkAvmUrBa4nFe1LXveGX6GsIPw==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@blockly/theme-tritanopia": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-2.0.14.tgz",
-      "integrity": "sha512-oAJpuQwYQ9DHhyeFweSeiGLrKl0mx2qBXjnTdS2areRqlYJKRUfLTTULN3/KojGSHlQ9VUPj8yHxhdvYHpmNeQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-2.0.16.tgz",
+      "integrity": "sha512-hOb8KFcFpZX3KPFNgCv4wPJrvyX742pVdn3nWmmpWaAaKD26NeaFmbh4F+Y2HQBQ0OIbvlX+R9e8PUBDVMGadw==",
       "dev": true,
       "engines": {
         "node": ">=8.17.0"
@@ -2247,14 +2247,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.7.tgz",
-      "integrity": "sha512-l4L6Do+tfeM2OK0GJsU7TUcM/1oN/N25xHm3Jb4z3OiDU4Lj8dIuxX9LpVMS9riSXQs42D1ieX7b85/r16H9Fw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+      "integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/type-utils": "5.30.7",
-        "@typescript-eslint/utils": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/type-utils": "5.33.0",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -2295,14 +2295,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.7.tgz",
-      "integrity": "sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/typescript-estree": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2322,13 +2322,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz",
-      "integrity": "sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2339,12 +2339,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.7.tgz",
-      "integrity": "sha512-nD5qAE2aJX/YLyKMvOU5jvJyku4QN5XBVsoTynFrjQZaDgDV6i7QHFiYCx10wvn7hFvfuqIRNBtsgaLe0DbWhw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+      "integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.30.7",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2365,9 +2365,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.7.tgz",
-      "integrity": "sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2378,13 +2378,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz",
-      "integrity": "sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2420,15 +2420,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.7.tgz",
-      "integrity": "sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+      "integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/typescript-estree": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -2444,12 +2444,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz",
-      "integrity": "sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.3.tgz",
-      "integrity": "sha512-6sufD+HiKjLk8BtF/mAZagnwr41TQqcj74W1m+qB4pFttXrSWiSsWRsBnJYRMxuAO7iuLcehaQhBbCs3LkoLVw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.4.tgz",
+      "integrity": "sha512-qGYrynzalzEHOMLJhZmADpuMXUH55nSTVgVd11Z1ZlVsm3NQ69ZVgBEaCSN+GsEUUpoui71g4oVzE2iHEHbAtw==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -4385,7 +4385,7 @@
     "node_modules/escodegen/node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -7225,9 +7225,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
+      "integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
       "dev": true
     },
     "node_modules/oauth-sign": {
@@ -7776,9 +7776,9 @@
       }
     },
     "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "node_modules/punycode": {
@@ -9532,7 +9532,7 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -9544,7 +9544,7 @@
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -9811,7 +9811,7 @@
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -10369,9 +10369,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
@@ -11674,23 +11674,23 @@
       }
     },
     "@blockly/block-test": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.15.tgz",
-      "integrity": "sha512-S9A763PH1ILv/OnXHJtwdDX0obHupXlh2ccai4/6ddaNt1cm6ePBjm7t2iNNAGT3vlgum/GpEdG02LtwNCfohA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-2.0.17.tgz",
+      "integrity": "sha512-nOnNV2vOEsWrGgn9LerSKZpv+nF9Og3IKJO+pUtAfu8XDDzu0C6Veq1bsUEGfXDpJCaoexwn8NiZtqJwl2F7DQ==",
       "dev": true,
       "requires": {}
     },
     "@blockly/dev-scripts": {
-      "version": "1.2.24",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-1.2.24.tgz",
-      "integrity": "sha512-hKjZjfcjUqRefIdusQwCxeDAWEFdFjrLzQQauJwh2ATfct0rqBjciCK7veytnrdOoBXzYN8n8gaDOsiL2TB39g==",
+      "version": "1.2.26",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-1.2.26.tgz",
+      "integrity": "sha512-2d+vVu5mnC7bfuIoS9amnvrmdBMewwe3z0EJ/jDACWNNXp7UwDn+yI162x+hyhmkFmvqvJGwKmKKhAiWUqt+iA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/core": "^7.8.6",
         "@babel/preset-env": "^7.8.6",
         "@babel/preset-typescript": "^7.9.0",
-        "@blockly/eslint-config": "^2.1.16",
+        "@blockly/eslint-config": "^2.1.17",
         "babel-loader": "^8.0.6",
         "chalk": "^4.0.0",
         "eslint": "^7.15.0",
@@ -11705,16 +11705,16 @@
       }
     },
     "@blockly/dev-tools": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-3.1.8.tgz",
-      "integrity": "sha512-NspvkxClFlBsYe9mxfi51QuVFYtUVcKtG9OmtxEoapk1G6K1JDp3jtwUfNd3U2UjMmFHZMP9OaJC5nQQBye3hw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-4.0.2.tgz",
+      "integrity": "sha512-Vb26ATIGRR/qm3D09OOZqghgaabkzT77OZOzvvAp5UY302a/GT15bTKsdZ1jtK/sGA4ZuBvC+3q5E+sJG9cDTQ==",
       "dev": true,
       "requires": {
-        "@blockly/block-test": "^2.0.14",
-        "@blockly/theme-dark": "^3.0.13",
-        "@blockly/theme-deuteranopia": "^2.0.13",
-        "@blockly/theme-highcontrast": "^2.0.13",
-        "@blockly/theme-tritanopia": "^2.0.13",
+        "@blockly/block-test": "^2.0.17",
+        "@blockly/theme-dark": "^3.0.16",
+        "@blockly/theme-deuteranopia": "^2.0.16",
+        "@blockly/theme-highcontrast": "^2.0.16",
+        "@blockly/theme-tritanopia": "^2.0.16",
         "chai": "^4.2.0",
         "dat.gui": "^0.7.7",
         "lodash.assign": "^4.2.0",
@@ -11724,9 +11724,9 @@
       }
     },
     "@blockly/eslint-config": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.16.tgz",
-      "integrity": "sha512-OTvY4gPM/FzqCk11fBDN2Kr7IO/HUpuw5PjxeHQQXUbUL2ODS8EMlQOJ0x22XTZ+j3TjENHBQ9bnEIMZs6efgg==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.17.tgz",
+      "integrity": "sha512-hNDj3nXMfKNzph8rG6sbRKU4ZiHcgt/wW7jP9NhzADN29TfpozaupDOD7BdhW98CFCLTD1HJtFdO3sHyP0bfOg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.0.0",
@@ -11737,30 +11737,30 @@
       }
     },
     "@blockly/theme-dark": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-3.0.14.tgz",
-      "integrity": "sha512-narn7BtQF/0lV0vzvKbtC8UMPyqHHSdNOEWNgK+RqccpcKKRaLtl6WsGd8vMr+AyFwUmF0L+0X5lFLn0qw9EFw==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-3.0.16.tgz",
+      "integrity": "sha512-a76DRJNcJ7TgCLkHevICUzhkMRYYdPpcg24OPuKMEnzrSUblT+VHuuElVLBDNs24wR/SRCnXC3qAiXwYi/bzdg==",
       "dev": true,
       "requires": {}
     },
     "@blockly/theme-deuteranopia": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-2.0.14.tgz",
-      "integrity": "sha512-qnTQS/BlIjTXyTaGjpqHoblZ3cJALytFWZ6A4acnJ13L/ExTe78kmyP64xuI3cPkkvLe9qtyEK+U4JZqqXAnEA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-2.0.16.tgz",
+      "integrity": "sha512-8lgh5AGIfANugVO9EQJ5woy6JZ8BUvlxxky0iRab6nIVDAlA6m4k+HiqKUbEThBh69vlvMObwZW2DNcxVpcVrA==",
       "dev": true,
       "requires": {}
     },
     "@blockly/theme-highcontrast": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-2.0.14.tgz",
-      "integrity": "sha512-zXV/ONIgKJZO3hGOIAgfvNZ1pRdwxk97w+n/kz1v/6n3xDyJUrl7CgXhO+WQOpePi6UTPUEdcoVGZAzd8u6AHg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-2.0.16.tgz",
+      "integrity": "sha512-3ffHBxmdQea7NcsWBNCgGctW6fNeHHIK5S9PQ4994p1i4FLID9cQCrIRdCvodkAvmUrBa4nFe1LXveGX6GsIPw==",
       "dev": true,
       "requires": {}
     },
     "@blockly/theme-tritanopia": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-2.0.14.tgz",
-      "integrity": "sha512-oAJpuQwYQ9DHhyeFweSeiGLrKl0mx2qBXjnTdS2areRqlYJKRUfLTTULN3/KojGSHlQ9VUPj8yHxhdvYHpmNeQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-2.0.16.tgz",
+      "integrity": "sha512-hOb8KFcFpZX3KPFNgCv4wPJrvyX742pVdn3nWmmpWaAaKD26NeaFmbh4F+Y2HQBQ0OIbvlX+R9e8PUBDVMGadw==",
       "dev": true,
       "requires": {}
     },
@@ -12107,14 +12107,14 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.7.tgz",
-      "integrity": "sha512-l4L6Do+tfeM2OK0GJsU7TUcM/1oN/N25xHm3Jb4z3OiDU4Lj8dIuxX9LpVMS9riSXQs42D1ieX7b85/r16H9Fw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
+      "integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/type-utils": "5.30.7",
-        "@typescript-eslint/utils": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/type-utils": "5.33.0",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -12135,52 +12135,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.30.7.tgz",
-      "integrity": "sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
+      "integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/typescript-estree": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.30.7.tgz",
-      "integrity": "sha512-7BM1bwvdF1UUvt+b9smhqdc/eniOnCKxQT/kj3oXtj3LqnTWCAM0qHRHfyzCzhEfWX0zrW7KqXXeE4DlchZBKw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
+      "integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7"
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.30.7.tgz",
-      "integrity": "sha512-nD5qAE2aJX/YLyKMvOU5jvJyku4QN5XBVsoTynFrjQZaDgDV6i7QHFiYCx10wvn7hFvfuqIRNBtsgaLe0DbWhw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
+      "integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.30.7",
+        "@typescript-eslint/utils": "5.33.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.30.7.tgz",
-      "integrity": "sha512-ocVkETUs82+U+HowkovV6uxf1AnVRKCmDRNUBUUo46/5SQv1owC/EBFkiu4MOHeZqhKz2ktZ3kvJJ1uFqQ8QPg==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
+      "integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.7.tgz",
-      "integrity": "sha512-tNslqXI1ZdmXXrHER83TJ8OTYl4epUzJC0aj2i4DMDT4iU+UqLT3EJeGQvJ17BMbm31x5scSwo3hPM0nqQ1AEA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
+      "integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/visitor-keys": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/visitor-keys": "5.33.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -12200,26 +12200,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.30.7.tgz",
-      "integrity": "sha512-Z3pHdbFw+ftZiGUnm1GZhkJgVqsDL5CYW2yj+TB2mfXDFOMqtbzQi2dNJIyPqPbx9mv2kUxS1gU+r2gKlKi1rQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
+      "integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.30.7",
-        "@typescript-eslint/types": "5.30.7",
-        "@typescript-eslint/typescript-estree": "5.30.7",
+        "@typescript-eslint/scope-manager": "5.33.0",
+        "@typescript-eslint/types": "5.33.0",
+        "@typescript-eslint/typescript-estree": "5.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.30.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.7.tgz",
-      "integrity": "sha512-KrRXf8nnjvcpxDFOKej4xkD7657+PClJs5cJVSG7NNoCNnjEdc46juNAQt7AyuWctuCgs6mVRc1xGctEqrjxWw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
+      "integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.30.7",
+        "@typescript-eslint/types": "5.33.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -12789,9 +12789,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.3.tgz",
-      "integrity": "sha512-6sufD+HiKjLk8BtF/mAZagnwr41TQqcj74W1m+qB4pFttXrSWiSsWRsBnJYRMxuAO7iuLcehaQhBbCs3LkoLVw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.4.tgz",
+      "integrity": "sha512-qGYrynzalzEHOMLJhZmADpuMXUH55nSTVgVd11Z1ZlVsm3NQ69ZVgBEaCSN+GsEUUpoui71g4oVzE2iHEHbAtw==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"
@@ -13730,7 +13730,7 @@
         "type-check": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -15910,9 +15910,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
+      "integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
       "dev": true
     },
     "oauth-sign": {
@@ -16322,9 +16322,9 @@
       }
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "punycode": {
@@ -17679,7 +17679,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -17688,7 +17688,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "type-check": {
@@ -17889,7 +17889,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -18296,9 +18296,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
-    "@blockly/dev-tools": "^3.1.8",
-    "blockly": "^8.0.3"
+    "@blockly/dev-scripts": "^1.2.26",
+    "@blockly/dev-tools": "^4.0.2",
+    "blockly": "^8.0.4"
   },
   "peerDependencies": {
-    "blockly": "^8.0.3"
+    "blockly": "^8.0.4"
   },
   "publishConfig": {},
   "eslintConfig": {

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -19,9 +19,10 @@ const registerDuplicate = function() {
   const duplicateOption = {
     displayText: function(scope) {
       let workableBlocksLength = 0;
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         if (duplicateOption.check(block)) {
           workableBlocksLength++;
         }
@@ -60,13 +61,14 @@ const registerDuplicate = function() {
         }
         block.pathObject.updateSelected(false);
       };
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       Blockly.Events.setGroup(true);
       if (!blockSelection.size) {
         apply(scope.block);
       }
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         apply(block);
       });
       Blockly.Events.setGroup(false);
@@ -93,9 +95,10 @@ const registerComment = function() {
     displayText: function(scope) {
       let workableBlocksLength = 0;
       const state = scope.block.getCommentIcon();
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         if (commentOption.check(block) &&
             (block.getCommentIcon() instanceof Blockly.Comment) ===
             (state instanceof Blockly.Comment)) {
@@ -148,13 +151,14 @@ const registerComment = function() {
           }
         }
       };
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       Blockly.Events.setGroup(true);
       if (!blockSelection.size) {
         apply(scope.block);
       }
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         apply(block);
       });
       Blockly.Events.setGroup(false);
@@ -174,9 +178,10 @@ const registerInline = function() {
     displayText: function(scope) {
       let workableBlocksLength = 0;
       const state = scope.block.getInputsInline();
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         if (inlineOption.check(block) &&
             block.getInputsInline() === state) {
           workableBlocksLength++;
@@ -229,13 +234,14 @@ const registerInline = function() {
           block.setInputsInline(state);
         }
       };
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       Blockly.Events.setGroup(true);
       if (!blockSelection.size) {
         apply(scope.block);
       }
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         apply(block);
       });
       Blockly.Events.setGroup(false);
@@ -256,9 +262,10 @@ const registerCollapseExpandBlock = function() {
     displayText: function(scope) {
       let workableBlocksLength = 0;
       const state = scope.block.isCollapsed();
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         if (collapseExpandOption.check(block) &&
             block.isCollapsed() === state) {
           workableBlocksLength++;
@@ -307,13 +314,14 @@ const registerCollapseExpandBlock = function() {
           block.setCollapsed(state);
         }
       };
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       Blockly.Events.setGroup(true);
       if (!blockSelection.size) {
         apply(scope.block);
       }
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         apply(block);
       });
       Blockly.Events.setGroup(false);
@@ -333,9 +341,10 @@ const registerDisable = function() {
     displayText: function(scope) {
       let workableBlocksLength = 0;
       const state = scope.block.isEnabled();
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         if (disableOption.check(block) &&
             block.isEnabled() === state) {
           workableBlocksLength++;
@@ -386,13 +395,14 @@ const registerDisable = function() {
           block.setEnabled(state);
         }
       };
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       Blockly.Events.setGroup(true);
       if (!blockSelection.size) {
         apply(scope.block);
       }
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         apply(block);
       });
       Blockly.Events.setGroup(false);
@@ -411,9 +421,10 @@ const registerDelete = function() {
   const deleteOption = {
     displayText: function(scope) {
       let descendantCount = 0;
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         if (block && !hasSelectedParent(block)) {
           // Count the number of blocks that are nested in this block.
           descendantCount += block.getDescendants(false).length;
@@ -450,13 +461,14 @@ const registerDelete = function() {
           }
         }
       };
-      const blockSelection = blockSelectionWeakMap.get(scope.block.workspace);
+      const workspace = scope.block.workspace;
+      const blockSelection = blockSelectionWeakMap.get(workspace);
       Blockly.Events.setGroup(true);
       if (!blockSelection.size) {
         apply(scope.block);
       }
       blockSelection.forEach(function(id) {
-        const block = scope.block.workspace.getBlockById(id);
+        const block = workspace.getBlockById(id);
         apply(block);
       });
       Blockly.Events.setGroup(false);


### PR DESCRIPTION
Sometimes in the deletion process, the block in the scope (`scope.block`, which is the block user right-clicked on for the Context menu) can get deleted prior to `blockSelection.forEach` completes, which leads to `scope.block.workspace` returing null. so this PR fixes this by getting `scope.block.workspace` before the loop and also applying this to other actions in the context menu.

Also updates package.json to the latest.

Signed-off-by: Hollow Man <hollowman@opensuse.org>