### PR TITLE
multiselect_controls: Fix crash on selecting a second time

### DIFF
--- a/src/multiselect_controls.js
+++ b/src/multiselect_controls.js
@@ -392,7 +392,7 @@ export class MultiselectControls {
     this.dragSelect_.subscribe('elementselect', (info) => {
       const element = info.item.parentElement;
       if (inMultipleSelectionModeWeakMap.get(this.workspace_) &&
-          element.dataset && element.dataset.id) {
+          element && element.dataset && element.dataset.id) {
         this.updateBlocks_(
             this.workspace_.getBlockById(element.dataset.id));
       }
@@ -400,7 +400,7 @@ export class MultiselectControls {
     this.dragSelect_.subscribe('elementunselect', (info) => {
       const element = info.item.parentElement;
       if (inMultipleSelectionModeWeakMap.get(this.workspace_) &&
-          element.dataset && element.dataset.id) {
+          element && element.dataset && element.dataset.id) {
         this.updateBlocks_(
             this.workspace_.getBlockById(element.dataset.id));
       }


### PR DESCRIPTION
This handles the case where `element` does not exist. This fixes the crash, but I'm not familiar enough with the code base to know if this might have any side effects.

To reproduce:
- Select `Zelos` renderer. It does not appear to happen with other renderers.
- Select a few blocks with `shift` key held down.
- Release `shift`, then press again to repeat selection.
- Observe crash:

https://github.com/mit-cml/workspace-multiselect/assets/12326241/2025d4b4-729e-4b1c-ab0d-402382126e9a

