### PR TITLE
Provide API for ignoring some multi-field updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ options = {
   bumpNeighbours: false,
 
   // Keep the fields of multiple selected same-type blocks with the same value
+  // See note below.  
   multiFieldUpdate: true,
 
   // Auto focus the workspace when the mouse enters.
@@ -96,6 +97,16 @@ multiselectPlugin.init(options);
 ## Known issues
 - [ ] Currently, we rely on DragSelect to know which block gets selected. DragSelect seems to listen to the "blocks". However, it actually works by listening to the SVG path element, which is always a rectangle with some transparent parts forming a block. For irregularly shaped blocks, if you click on the transparent area that within the SVG rectangle, it will still get selected. (a mitigation has already been introduced in v0.1.4, but a proper fix should be that Blockly implements some kind of API, so that we can know for sure where the block actually locates.)
 
+### Note on multi-field updates
+When the multiFieldUpdate option is enable, the plugin will automatically update the fields of all selected blocks with the
+same type. This can cause issues when you have multiple field on a block and one field is dependent on another. 
+For example, if you have a block with a dropdown field and another, dependent, field which is programmatically updated 
+(e.g. in the dropdown field's validator) based on the value of the dropdown field, then the
+ multi-field update may interfere with the programmatic update.  In this situation, you only want to multi-field
+update to update the dropdown fields. To do this, you can use the `Multiselect.withoutMultiFieldUpdates` wrapper function
+within the function which updates the dependent field.  It allows you to temporarily turn off the multi-field update within the
+scope of its wrapped input function.
+
 ## API
 
 - `Multiselect.init`: Initialize the plugin.
@@ -103,6 +114,7 @@ multiselectPlugin.init(options);
 - `MultiselectBlockDragger`: The customized block dragger for multiple selection.
 - `blockSelectionWeakMap`: The WeakMap storing set of currently selected block ids by workspace svg.
 - `inMultipleSelectionModeWeakMap`: The WeakMap storing whether the plugin is in multiple selection mode by workspace svg.
+- `Multiselect.withoutMultiFieldUpdates`: A wrapper function to ignore multi-field updates.
 
 ## Credit
 - [DragSelect](https://github.com/ThibaultJanBeyer/DragSelect): This plugin uses DragSelect to realize the "drag a rectangle to select multiple blocks" feature. The patching PR [#143](https://github.com/ThibaultJanBeyer/DragSelect/pull/143) and [#165](https://github.com/ThibaultJanBeyer/DragSelect/pull/165) made all this possible, and these PRs are included in [v2.6.0](https://github.com/ThibaultJanBeyer/DragSelect/releases/tag/v2.6.0).

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ scope of its wrapped input function.
 
 - `Multiselect.init`: Initialize the plugin.
 - `Multiselect.dispose`: Dispose the plugin.
-- `Multiselect.multiFieldUpdateGroupID`: The event group id for multi-field updates.
 - `MultiselectBlockDragger`: The customized block dragger for multiple selection.
 - `blockSelectionWeakMap`: The WeakMap storing set of currently selected block ids by workspace svg.
 - `inMultipleSelectionModeWeakMap`: The WeakMap storing whether the plugin is in multiple selection mode by workspace svg.

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -121,14 +121,16 @@ export class Multiselect {
    * @param {function} func The function to call.
    */
   withoutMultiFieldUpdates(func) {
-      const oldGroup = Blockly.Events.getGroup();
-      // Note that this depends on the fact that eventListener_ will ignore events with a group ID.
+    let oldGroup = Blockly.Events.getGroup();
+    // Note that this depends on the fact that eventListener_ will ignore events with a group ID.
+    if (!oldGroup) {
       Blockly.Events.setGroup("ignoreMultiFieldUpdates");
-      try {
-          func();
-      } finally {
-        Blockly.Events.setGroup(oldGroup);
-      }
+    }
+    try {
+        func();
+    } finally {
+      Blockly.Events.setGroup(oldGroup);
+    }
   }
 
   /**

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -119,7 +119,7 @@ export class Multiselect {
    * Ignore multi-field updates within the given function.
    * @param {function} func The function to call.
    */
-  withoutMultiFieldUpdates(func) {
+  static withoutMultiFieldUpdates(func) {
     let oldGroup = Blockly.Events.getGroup();
     // Note that this depends on the fact that eventListener_ will ignore events with a group ID.
     if (!oldGroup) {

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -115,6 +115,21 @@ export class Multiselect {
   }
 
   /**
+   * Ignore multi-field updates within the given function.
+   * @param {function} func The function to call.
+   */
+  withoutMultiFieldUpdates(func) {
+      const oldGroup = Blockly.Events.getGroup();
+      // Note that this depends on the fact that eventListener_ will ignore events with a group ID.
+      Blockly.Events.setGroup("ignoreMultiFieldUpdates");
+      try {
+          func();
+      } finally {
+        Blockly.Events.setGroup(oldGroup);
+      }
+  }
+
+  /**
    * Unbind the events and replace with original registration.
    * @param {boolean} keepRegistry Keep the context menu and shortcut registry.
    */

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -33,7 +33,6 @@ export class Multiselect {
     this.blockSelection_ = blockSelectionWeakMap.get(this.workspace_);
     inMultipleSelectionModeWeakMap.set(this.workspace_, false);
     BaseBlockDraggerWeakMap.set(this.workspace_, Blockly.BlockDragger);
-    this.multiFieldUpdateGroupID = '';
     this.fieldIntermediateChangeGroupIds_ = new Set();
     this.useCopyPasteCrossTab_ = true;
     this.useCopyPasteMenu_ = true;
@@ -280,7 +279,6 @@ export class Multiselect {
         Blockly.Events.setGroup(true);
         e.group = Blockly.Events.getGroup();
       }
-      this.multiFieldUpdateGroupID = e.group;
       try {
         const blockType = this.workspace_.getBlockById(e.blockId).type;
         // Update the fields to the same value for
@@ -305,7 +303,6 @@ export class Multiselect {
         } else {
           Blockly.Events.setGroup(currentGroup);
         }
-        this.multiFieldUpdateGroupID = '';
       }
     }
   }

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -123,7 +123,7 @@ export class Multiselect {
     let oldGroup = Blockly.Events.getGroup();
     // Note that this depends on the fact that eventListener_ will ignore events with a group ID.
     if (!oldGroup) {
-      Blockly.Events.setGroup("ignoreMultiFieldUpdates");
+      Blockly.Events.setGroup(true);
     }
     try {
         func();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #57

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Allows a user of the plugin to temporarily disable mult-ifield updates within a particular scope.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

Multi-field updates can cause issues with dependent fields on the same block.  See issue #57 anad the updated README file in this PR for some more details.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

This PR includes additions to the README file.

### Additional Information

<!-- Anything else we should know? -->
