### PR TITLE
fix DELETE_X_BLOCKS count message

### DIFF
--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -609,8 +609,8 @@ const registerDelete = function() {
       let descendantCount = 0;
       const workspace = scope.block.workspace;
       const dragSelection = dragSelectionWeakMap.get(workspace);
-      dragSelection.forEach(function(id) {
-        const block = workspace.getBlockById(id);
+
+      const countDescendants = function(block) {
         if (block && !hasSelectedParent(block)) {
           // Count the number of blocks that are nested in this block.
           descendantCount += block.getDescendants(false).length;
@@ -625,7 +625,19 @@ const registerDelete = function() {
             descendantCount -= nextBlock.getDescendants(false).length;
           }
         }
-      });
+      };
+
+      if (!dragSelection.size) {
+        // Handle single block selection
+        countDescendants(scope.block);
+      } else {
+        // Handle multiple block selection
+        dragSelection.forEach(function(id) {
+          const block = workspace.getBlockById(id);
+          countDescendants(block);
+        });
+      }
+
       return (descendantCount <= 1) ?
         Blockly.Msg['DELETE_BLOCK'] :
         Blockly.Msg['DELETE_X_BLOCKS'].replace('%1', String(descendantCount));


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

<img width="374" alt="Screenshot 2025-06-07 at 20 33 07" src="https://github.com/user-attachments/assets/14528a8d-b9d6-4e4b-90b2-41ddcd786777" />

## The details
As seen in the image, when you right click a block with children, the delete message is not updated to include the children. Only if you manually select all blocks they will be counted.

### Resolves
Problem: The delete function only counted descendants when multiple blocks were selected (dragSelection had items). For single block right-clicks, dragSelection was empty, so the counting logic never ran.

Solution: Added logic to handle single block selection by extracting descendant counting into a helper function and running it if dragSelection.size is 0 (single block)


### Additional Information

This was reported in App Inventor at https://github.com/mit-cml/appinventor-sources/issues/3390
I haven't yet tested if Evan's fork works with the same fix but will do that next (cause it is a 10.4 branch). The issue there seems to be different, and it seems to be related to block selection.
