### PR TITLE
Fix delete key deleting block in workspace rather than mutator

### DIFF
--- a/src/multiselect_shortcut.js
+++ b/src/multiselect_shortcut.js
@@ -30,7 +30,8 @@ const registerShortcutDelete = function() {
       }
       const selected = Blockly.common.getSelected();
       if (selected && selected.isInMutator) {
-        return selected.isDeletable();  // Blocks in the mutator workspace are always deletable.
+        // Blocks in the mutator workspace are always deletable.
+        return selected.isDeletable();
       }
       const dragSelection = dragSelectionWeakMap.get(workspace);
       if (!dragSelection.size) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

Note that after this plugin was upgraded to Blockly 11 instead of the block in the workspace being deleted you get the unhandled exception below, which this same fix resolves.
```
Cannot read properties of undefined (reading 'has')
TypeError: Cannot read properties of undefined (reading 'has')
    at hasSelectedParent (webpack-internal:///./src/global.js:108:59)
    at Object.check (webpack-internal:///./src/multiselect_shortcut.js:54:72)
    at Object.preconditionFn (webpack-internal:///./src/multiselect_shortcut.js:40:31)
    at ShortcutRegistry$$module$build$src$core$shortcut_registry.onKeyDown (webpack-internal:///./node_modules/blockly/blockly_compressed.js:1299:71)
    at onKeyDown$$module$build$src$core$inject (webpack-internal:///./node_modules/blockly/blockly_compressed.js:432:269)
    at HTMLDivElement.f (webpack-internal:///./node_modules/blockly/blockly_compressed.js:97:159)
```

https://github.com/mit-cml/appinventor-sources/pull/3418
https://github.com/mit-cml/appinventor-sources/issues/3394
https://community.appinventor.mit.edu/t/help-test-nb200b/137740/16
