### PR TITLE
optimize delete block count; depth-first traversal

### DIFF
--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -638,9 +638,9 @@ const registerDelete = function() {
       };
 
       const isInMultiselection = dragSelection &&
-        dragSelection.has(scope.block.id);
+          dragSelection.has(scope.block.id);
 
-      if (!isInMultiselection) {
+      if (!dragSelection || dragSelection.size === 0 || !isInMultiselection) {
         // Handle single block selection
         countDescendants(scope.block);
       } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

This is a follow up to https://github.com/mit-cml/workspace-multiselect/pull/107 from https://github.com/ewpatton/workspace-multiselect/pull/1. As part of the merge I updated it to skip shadow blocks in the count as that logic was not in the fork where this fix was made. This fix has the added benefit of resolving a bug in this version of the plugin where shadow blocks were subtracted twice if they were descendants of next block.