### PR TITLE
Include shadow blocks in delete count

### DIFF
--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -614,7 +614,6 @@ const registerDelete = function() {
         if (!block || hasSelectedParent(block)) return;
 
         const countBlockAndDescendants = function(currentBlock) {
-          if (currentBlock.isShadow()) return 0;
           let count = 1; // Initial block
           for (const input of currentBlock.inputList) {
             if (input.connection && input.connection.targetBlock()) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Includes shadow blocks in delete count.

### Reason for Changes

Blockly's built-in delete all blocks, that appears when you right click anywhere on the workspace where there isn't a block, includes shadow blocks in the count displayed.
