### PR TITLE
Preserve multiselection when shift held on right click

### DIFF
--- a/src/multiselect_controls.js
+++ b/src/multiselect_controls.js
@@ -392,13 +392,18 @@ export class MultiselectControls {
           !(Blockly.getSelected() instanceof MultiselectDraggable)) {
         // Blockly.getSelected() is not a multiselectDraggable
         // and selected block is not in dragSelection
-        for (const draggable of this.multiDraggable.subDraggables) {
-          draggable[0].unselect();
+        if (this.dragSelection.size > 1) {
+          // Preserve multiselection when shift held on right click
+          Blockly.common.setSelected(this.multiDraggable);
+        } else {
+          for (const draggable of this.multiDraggable.subDraggables) {
+            draggable[0].unselect();
+          }
+          this.multiDraggable.clearAll_();
+          this.dragSelection.clear();
+          this.lastSelectedElement_ = Blockly.getSelected();
+          inPasteShortcut.set(this.workspace_, false);
         }
-        this.multiDraggable.clearAll_();
-        this.dragSelection.clear();
-        this.lastSelectedElement_ = Blockly.getSelected();
-        inPasteShortcut.set(this.workspace_, false);
       }
     } else {
       // In multiselect mode


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #112