### PR TITLE
Add regression tests for block bounds selection

### DIFF
--- a/test-e2e/selection/multiselect/block.spec.ts
+++ b/test-e2e/selection/multiselect/block.spec.ts
@@ -374,3 +374,49 @@ test("select all blocks via context menu", async ({ page, act }) => {
 	expect(await getHighlightedBlockIds(page)).toEqual(["block1", "block2"]);
 	expect(await getSelectedId(page)).toBe(await getMultiselectDraggableId(page));
 });
+
+test("shift clicking empty space inside block bounds selects nothing", async ({
+	page,
+	act,
+}) => {
+	test.fail(
+		true,
+		"https://github.com/mit-cml/workspace-multiselect/issues/56",
+	);
+	await act(loadBlocks(page, [{ type: "controls_if", id: "if" }]));
+	const bounds = (await getBlock(page, { id: "if" })).bounds;
+
+	await act(page.keyboard.down("Shift"));
+	await act(page.mouse.click(bounds.left, bounds.top));
+
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+	expect(await getSelectedId(page)).toBeNull();
+});
+
+test("shift clicking child inside parent bounds selects child", async ({
+	page,
+	act,
+}) => {
+	await act(
+		loadBlocks(page, [
+			{
+				type: "controls_if",
+				id: "parent",
+				inputs: {
+					DO0: { block: { type: "variables_set", id: "child" } },
+				},
+			},
+		]),
+	);
+	const childBounds = (await getBlock(page, { id: "child" })).bounds;
+	const point = [
+		childBounds.left + 1,
+		(childBounds.top + childBounds.bottom) / 2,
+	] as const;
+
+	await act(page.keyboard.down("Shift"));
+	await act(page.mouse.click(...point));
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["child"]);
+	expect(await getSelectedId(page)).toBe("child");
+});

--- a/test-e2e/selection/select/block.spec.ts
+++ b/test-e2e/selection/select/block.spec.ts
@@ -97,3 +97,43 @@ test("clicking empty space clears selection", async ({ page, act }) => {
 	expect(await getHighlightedBlockIds(page)).toEqual([]);
 	expect(await getSelectedId(page)).toBeNull();
 });
+
+test("clicking empty space inside block bounds selects nothing", async ({
+	page,
+	act,
+}) => {
+	await act(loadBlocks(page, [{ type: "controls_if", id: "if" }]));
+	const bounds = (await getBlock(page, { id: "if" })).bounds;
+
+	await act(page.mouse.click(bounds.left, bounds.top));
+
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+	expect(await getSelectedId(page)).toBeNull();
+});
+
+test("clicking child inside parent bounds selects child", async ({
+	page,
+	act,
+}) => {
+	await act(
+		loadBlocks(page, [
+			{
+				type: "controls_if",
+				id: "parent",
+				inputs: {
+					DO0: { block: { type: "variables_set", id: "child" } },
+				},
+			},
+		]),
+	);
+	const childBounds = (await getBlock(page, { id: "child" })).bounds;
+	const point = [
+		childBounds.left + 1,
+		(childBounds.top + childBounds.bottom) / 2,
+	] as const;
+
+	await act(page.mouse.click(...point));
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["child"]);
+	expect(await getSelectedId(page)).toBe("child");
+});


### PR DESCRIPTION
Confirms the empty space bug and parent filter mitigation for https://github.com/mit-cml/workspace-multiselect/issues/56.