### PR TITLE
Fix deselection when grabbing multiselected block's shadow input

### DIFF
--- a/src/multiselect_draggable.js
+++ b/src/multiselect_draggable.js
@@ -144,9 +144,15 @@ export class MultiselectDraggable {
    */
   pointerDownEventHandlerCapture_(event) {
     if (!inMultipleSelectionModeWeakMap.get(this.workspace)) {
-      const clickedBlock = this.workspace.getBlockById(
+      let clickedBlock = this.workspace.getBlockById(
           event.target.closest('[data-id]').getAttribute('data-id'));
-      if (!this.subDraggables.has(clickedBlock)) {
+
+      // Find first non-shadow block parent, because shadow blocks can't be grabbed
+      while (clickedBlock && clickedBlock.isShadow()) {
+        clickedBlock = clickedBlock.getParent();
+      }
+
+      if (clickedBlock && !this.subDraggables.has(clickedBlock)) {
         this.clearAll_();
         this.dragSelection.clear();
       }

--- a/test-e2e/selection/multiselect/block.spec.ts
+++ b/test-e2e/selection/multiselect/block.spec.ts
@@ -176,6 +176,51 @@ test("clicking selected child block keeps selection", async ({ page, act }) => {
 	expect(await getSelectedId(page)).toBe(await getMultiselectDraggableId(page));
 });
 
+test("clicking selected child block's shadow block input keeps selection", async ({page, act}) => {
+	await act(
+		loadBlocks(page, [
+			{
+				type: "math_arithmetic",
+				id: "other",
+			},
+			{
+				type: "controls_repeat_ext",
+				id: "parent",
+				inputs: {
+					TIMES: {
+						shadow: {
+							type: "math_number",
+							id: "shadow",
+							fields: {
+								NUM: 10,
+							},
+						},
+					},
+				},
+			},
+		]),
+	);
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getBlock(page, {id: "other"})).centerTop),
+	);
+	await act(
+		page.mouse.click(...(await getBlock(page, {id: "parent"})).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	await act(
+		page.mouse.click(...(await getBlock(page, {id: "shadow"})).centerTop),
+	);
+
+	expect(await getHighlightedBlockIds(page)).toEqual([
+		"other",
+		"parent",
+	]);
+	expect(await getSelectedId(page)).toBe(await getMultiselectDraggableId(page));
+});
+
 test("clicking unselected block clears selection and selects it", async ({
 	page,
 	act,

--- a/test-e2e/selection/select/block.spec.ts
+++ b/test-e2e/selection/select/block.spec.ts
@@ -43,6 +43,38 @@ test("clicking selected block keeps selection", async ({ page, act }) => {
 	expect(await getSelectedId(page)).toBe("block1");
 });
 
+test("clicking selected block's shadow block input keeps visual selection", async ({ page, act }) => {
+	await act(
+		loadBlocks(page, [
+			{
+				type: "controls_repeat_ext",
+				id: "parent",
+				inputs: {
+					TIMES: {
+						shadow: {
+							type: "math_number",
+							id: "shadow",
+							fields: {
+								NUM: 10,
+							},
+						},
+					},
+				},
+			},
+		]),
+	);
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "parent" })).centerTop),
+	);
+
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "shadow" })).centerTop),
+	);
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["parent"]);
+	expect(await getSelectedId(page)).toBe("shadow");
+});
+
 test("clicking child of selected block selects it", async ({ page, act }) => {
 	await act(
 		loadBlocks(page, [


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #119. Problem with shadow blocks

### Proposed Changes

Iterate over block's parent chain until we find non-shadow block. Shadow blocks cannot be grabbed, so they do no deselect item

### Reason for Changes

N/A

### Test Coverage

added `clicking unselected block clears selection and selects it` test that covers this specific scenario. Without this fix test fails

### Documentation

N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information


N/A
<!-- Anything else we should know? -->
