### PR TITLE
Fix shadow block deselecting main block during multiselect

### DIFF
--- a/src/multiselect_controls.js
+++ b/src/multiselect_controls.js
@@ -491,15 +491,37 @@ export class MultiselectControls {
       }
       return toRemove;
     };
+    // Filter out shadow blocks from selection
+    const filterShadows = (list) => {
+      const toRemove = [];
+      for (const [element] of list.entries()) {
+        const elementParent = element.parentElement;
+        if (elementParent && elementParent.dataset && elementParent.dataset.id) {
+          const block = getByID(this.workspace_, elementParent.dataset.id);
+          if (block && block?.isShadow?.()) {
+            toRemove.push(element);
+          }
+        }
+      }
+      return toRemove;
+    };
+
     this.dragSelect_.Selection.filterSelected = (
         {selectorRect, select: _select, unselect: _unselect}) => {
       const select = _select; const unselect = _unselect;
-      const toRemove = filterParent(select, selectorRect);
-      toRemove.forEach((el) => {
+
+      const shadowsToRemove = filterShadows(select);
+      shadowsToRemove.forEach((el) => {
+        select.delete(el);
+      });
+      
+      const parentsToRemove = filterParent(select, selectorRect);
+      parentsToRemove.forEach((el) => {
         const rect = select.get(el);
         select.delete(el);
         unselect.set(el, rect);
       });
+
       return {select, unselect};
     };
 

--- a/test-e2e/selection/multiselect/block.spec.ts
+++ b/test-e2e/selection/multiselect/block.spec.ts
@@ -420,3 +420,83 @@ test("shift clicking child inside parent bounds selects child", async ({
 	expect(await getHighlightedBlockIds(page)).toEqual(["child"]);
 	expect(await getSelectedId(page)).toBe("child");
 });
+
+test("shift clicking block's shadow block input selects main block", async ({
+	page,
+	act,
+}) => {
+	await act(
+		loadBlocks(page, [
+			{
+				type: "controls_repeat_ext",
+				id: "block",
+				inputs: {
+					TIMES: {
+						shadow: {
+							type: "math_number",
+							id: "shadow",
+							fields: {
+								NUM: 10,
+							},
+						},
+					},
+				},
+			},
+		]),
+	);
+
+	await act(page.keyboard.down("Shift"));
+
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "shadow" })).centerTop),
+	);
+
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["block"]);
+	expect(await getSelectedId(page)).toBe("block");
+});
+
+test("shift clicking block's shadow block input adds main block into existing multiselection", async ({
+	page,
+	act,
+}) => {
+	await act(
+		loadBlocks(page, [
+			{ type: "math_number", id: "block1" },
+			{ type: "math_number", id: "block2" },
+			{
+				type: "controls_repeat_ext",
+				id: "block3",
+				inputs: {
+					TIMES: {
+						shadow: {
+							type: "math_number",
+							id: "shadow",
+							fields: {
+								NUM: 10,
+							},
+						},
+					},
+				},
+			},
+		]),
+	);
+
+	await act(page.keyboard.down("Shift"));
+
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "block1" })).centerTop),
+	);
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "block2" })).centerTop),
+	);
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "shadow" })).centerTop),
+	);
+
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["block1", "block2", "block3"]);
+	expect(await getSelectedId(page)).toBe(await getMultiselectDraggableId(page));
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #139

### Proposed Changes

Added filtering for shadow blocks during selection
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Selecting shadow block should select its parent. Since during drag selection both parent and shadow block might end up inside the selection, we may end up calling update on the same block twice without any way to track if it was checked already. It's best if we just filter out shadow blocks early
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

This is only multiselect behaviour's. Added 2 tests:
1) shift clicking on shadow block should select parent
2) adding shadow block to existing multiselection should add its parent
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

N/A
<!-- Anything else we should know? -->
