### PR TITLE
Fix keyboard shortcuts (Copy/Cut/Delete) when using lasso selection

### DIFF
--- a/src/multiselect_controls.js
+++ b/src/multiselect_controls.js
@@ -509,6 +509,7 @@ export class MultiselectControls {
           element && element.dataset && element.dataset.id) {
         this.updateDraggables_(
             getByID(this.workspace_, element.dataset.id));
+        this.updateMultiselect();
       }
     });
     this.dragSelect_.subscribe('elementunselect', (info) => {
@@ -517,6 +518,7 @@ export class MultiselectControls {
           element && element.dataset && element.dataset.id) {
         this.updateDraggables_(
             getByID(this.workspace_, element.dataset.id));
+        this.updateMultiselect();
       }
     });
     if (byIcon) {

--- a/src/multiselect_shortcut.js
+++ b/src/multiselect_shortcut.js
@@ -87,13 +87,17 @@ const registerShortcutDelete = function() {
       const dragSelection = dragSelectionWeakMap.get(workspace);
 
       // Handle the case where MultiselectDraggable is in use
-      if (selected && selected instanceof MultiselectDraggable) {
-        for (const element of selected.subDraggables) {
-          selected.removeSubDraggable_(element[0]);
-          apply(element[0]);
-        }
+      if (dragSelection.size) {
+        dragSelection.forEach(function(id) {
+          const element = getByID(workspace, id);
+          if (selected instanceof MultiselectDraggable) {
+            selected.removeSubDraggable_(element);
+          }
+          apply(element);
+        });
         dragSelection.clear();
-      } else if (!dragSelection.size) {
+        if (selected instanceof MultiselectDraggable) selected.clearAll_();
+      } else {
         apply(selected);
       }
 
@@ -169,11 +173,11 @@ const registerCopy = function(useCopyPasteCrossTab) {
       Blockly.Events.setGroup(true);
 
       // Handle the case where MultiselectDraggable is in use
-      if (selected && selected instanceof MultiselectDraggable) {
-        for (const element of selected.subDraggables) {
-          apply(element[0]);
-        }
-      } else if (!dragSelection.size) {
+      if (dragSelection.size) {
+        dragSelection.forEach(function(id) {
+          apply(getByID(workspace, id));
+        });
+      } else {
         apply(selected);
       }
 
@@ -284,12 +288,15 @@ const registerCut = function(useCopyPasteCrossTab) {
       Blockly.Events.setGroup(true);
 
       // Handle the case where MultiselectDraggable is in use
-      if (selected && selected instanceof MultiselectDraggable) {
-        for (const element of selected.subDraggables) {
-          apply(element[0]);
-          selected.removeSubDraggable_(element[0]);
-        }
-      } else if (!dragSelection.size) {
+      if (dragSelection.size) {
+        dragSelection.forEach(function(id) {
+          const element = getByID(workspace, id);
+          apply(element);
+          if (selected instanceof MultiselectDraggable) {
+            selected.removeSubDraggable_(element);
+          }
+        });
+      } else {
         apply(selected);
       }
       dragSelection.clear();

--- a/src/multiselect_shortcut.js
+++ b/src/multiselect_shortcut.js
@@ -87,17 +87,13 @@ const registerShortcutDelete = function() {
       const dragSelection = dragSelectionWeakMap.get(workspace);
 
       // Handle the case where MultiselectDraggable is in use
-      if (dragSelection.size) {
-        dragSelection.forEach(function(id) {
-          const element = getByID(workspace, id);
-          if (selected instanceof MultiselectDraggable) {
-            selected.removeSubDraggable_(element);
-          }
-          apply(element);
-        });
+      if (selected && selected instanceof MultiselectDraggable) {
+        for (const element of selected.subDraggables) {
+          selected.removeSubDraggable_(element[0]);
+          apply(element[0]);
+        }
         dragSelection.clear();
-        if (selected instanceof MultiselectDraggable) selected.clearAll_();
-      } else {
+      } else if (!dragSelection.size) {
         apply(selected);
       }
 
@@ -173,11 +169,11 @@ const registerCopy = function(useCopyPasteCrossTab) {
       Blockly.Events.setGroup(true);
 
       // Handle the case where MultiselectDraggable is in use
-      if (dragSelection.size) {
-        dragSelection.forEach(function(id) {
-          apply(getByID(workspace, id));
-        });
-      } else {
+      if (selected && selected instanceof MultiselectDraggable) {
+        for (const element of selected.subDraggables) {
+          apply(element[0]);
+        }
+      } else if (!dragSelection.size) {
         apply(selected);
       }
 
@@ -288,15 +284,12 @@ const registerCut = function(useCopyPasteCrossTab) {
       Blockly.Events.setGroup(true);
 
       // Handle the case where MultiselectDraggable is in use
-      if (dragSelection.size) {
-        dragSelection.forEach(function(id) {
-          const element = getByID(workspace, id);
-          apply(element);
-          if (selected instanceof MultiselectDraggable) {
-            selected.removeSubDraggable_(element);
-          }
-        });
-      } else {
+      if (selected && selected instanceof MultiselectDraggable) {
+        for (const element of selected.subDraggables) {
+          apply(element[0]);
+          selected.removeSubDraggable_(element[0]);
+        }
+      } else if (!dragSelection.size) {
         apply(selected);
       }
       dragSelection.clear();

--- a/test-e2e/selection/multiselect/block.spec.ts
+++ b/test-e2e/selection/multiselect/block.spec.ts
@@ -420,3 +420,58 @@ test("shift clicking child inside parent bounds selects child", async ({
 	expect(await getHighlightedBlockIds(page)).toEqual(["child"]);
 	expect(await getSelectedId(page)).toBe("child");
 });
+
+test("dragging rectangle selects blocks when multiselect is enabled via icon", async ({ page, act }) => {
+	await act(
+		loadBlocks(page, [
+			{ type: "math_number", id: "block1" },
+			{ type: "math_number", id: "block2" },
+		]),
+	);
+
+	await act(page.locator('.blocklyMultiselect').click());
+
+	const block1Bounds = (await getBlock(page, { id: "block1" })).bounds;
+	const block2Bounds = (await getBlock(page, { id: "block2" })).bounds;
+	const gridSpacing = await getGridSpacing(page);
+	if (gridSpacing === null) throw new Error("Workspace has no grid");
+	const halfGridSpacing = gridSpacing / 2;
+
+	await act(
+		page.mouse.move(
+			block1Bounds.left - halfGridSpacing,
+			block1Bounds.top - halfGridSpacing,
+		),
+	);
+	await act(page.mouse.down());
+	await act(
+		page.mouse.move(
+			block2Bounds.right + halfGridSpacing,
+			block2Bounds.bottom + halfGridSpacing,
+		),
+	);
+	await act(page.mouse.up());
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["block1", "block2"]);
+	
+	expect(await getSelectedId(page)).toBe(await getMultiselectDraggableId(page));
+});
+
+test("shortcuts work after lasso selection via icon", async ({ page, act }) => {
+	await act(
+		loadBlocks(page, [
+			{ type: "math_number", id: "block1" },
+		]),
+	);
+
+	await act(page.locator('.blocklyMultiselect').click());
+	const bounds = (await getBlock(page, { id: "block1" })).bounds;
+	await act(page.mouse.move(bounds.left - 10, bounds.top - 10));
+	await act(page.mouse.down());
+	await act(page.mouse.move(bounds.right + 10, bounds.bottom + 10));
+	await act(page.mouse.up());
+
+	await page.keyboard.press("Delete");
+
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/mit-cml/workspace-multiselect/issues/144

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Modified registerShortcutDelete, registerCopy, and registerCut in multiselect_shortcut.js.
The updated logic now checks the dragSelection map directly within the shortcut callbacks. If the map is not empty, the shortcuts will operate on the contained blocks/comments, even if Blockly.common.getSelected() does not return a MultiselectDraggable proxy instance at that moment.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Reason for Changes
In certain states — specifically when multiselect mode is toggled via an external UI button or when using Lasso selection — the internal dragSelection map becomes populated, but the global Blockly selection state might not yet be synchronized with the MultiselectDraggable wrapper.
Before this change, shortcuts would only work if getSelected() returned a MultiselectDraggable instance, causing them to fail during Lasso selection. This PR ensures that visual selection (the blocks you actually see highlighted) always matches the shortcut behavior.

### Test Coverage

Manual testing was performed in Chrome:
1. Enabled multiselect mode via an external toggle.
2. Selected multiple blocks using Lasso (rectangular) selection.
3. Verified that the Delete key successfully removes all selected blocks.
4. Verified that Ctrl+C and Ctrl+V successfully copy and paste the entire selection.
5. Verified that standard Shift+Click selection and single-block selection still function as expected without regressions.

### Documentation

N/A

### Additional Information

N/A
