### PR TITLE
Fix copy/paste issues and mutators

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -61,6 +61,12 @@ export const registeredShortcut = [];
  */
 let timestamp = 0;
 
+/**
+ * Store the id of mutator workspace which elements were copied from.
+ * `null` if nothing is copied or if elements were not copied from mutator workspace
+ */
+let copyMutatorId = null;
+
 // TODO: Update custom enum below into actual enum
 //  if plugin is updated to TypeScript.
 /**
@@ -117,6 +123,10 @@ export const getByID = function(workspace, id) {
  * Store copy information for blocks in localStorage.
  */
 export const dataCopyToStorage = function() {
+  if (copyMutatorId) {
+    localStorage.removeItem('blocklyStashMulti')
+    return;
+  }
   const storage = [];
   copyData.forEach((data) => {
     delete data['source'];
@@ -190,12 +200,16 @@ export const copyCheckCallback = (element) => {
 export const copyCallback = (workspace, useCopyPasteCrossTab) => {
   copyData.clear();
   workspace.hideChaff();
+  copyMutatorId = null;
   const blockList = [];
   const apply = function(element) {
     if (copyCheckCallback(element)) {
       copyData.add(JSON.stringify(element.toCopyData()));
       if (element instanceof Blockly.BlockSvg) {
         blockList.push(element.id);
+        if (element.isInMutator) {
+          copyMutatorId = element.workspace.id;
+        }
       }
     }
   };
@@ -215,7 +229,7 @@ export const copyCallback = (workspace, useCopyPasteCrossTab) => {
   connectionDBList.length = 0;
   blockList.forEach(function(id) {
     const block = workspace.getBlockById(id);
-    const parentBlock = block.getParent();
+    const parentBlock = block?.getParent();
     if (parentBlock && blockList.indexOf(parentBlock.id) !== -1 &&
         parentBlock.getNextBlock() === block) {
       connectionDBList.push([
@@ -243,6 +257,9 @@ export const cutCallback = (workspace, useCopyPasteCrossTab) => {
     if (copyCheckCallback(element)) {
       copyData.add(JSON.stringify(element.toCopyData()));
       elementList.push(element.id);
+      if (element.isInMutator) {
+        copyMutatorId = element.workspace.id;
+      }
     }
   };
   const applyDelete = function(element) {
@@ -365,13 +382,19 @@ export const pasteCallback = (workspace, useCopyPasteCrossTab) => {
     if (workspace.isFlyout) {
       workspace = workspace.targetWorkspace;
     }
+    if (copyMutatorId) {
+      workspace = Blockly.common.getWorkspaceById(copyMutatorId);
+    }
+    if (!workspace) {
+      return;
+    }
     if (data.typeCounts &&
         workspace.isCapacityAvailable(data.typeCounts)) {
       const element = getPasteBlock(data, workspace);
       if (element) {
         blockList.push(element);
       }
-      if (element.type !== 'drag_to_dupe') {
+      if (element.type !== 'drag_to_dupe' && !copyMutatorId) {
         dragSelectionWeakMap.get(workspace).add(element.id);
         multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
       }
@@ -380,8 +403,10 @@ export const pasteCallback = (workspace, useCopyPasteCrossTab) => {
       if (element) {
         element.select();
       }
-      dragSelectionWeakMap.get(workspace).add(element.id);
-      multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
+      if (!copyMutatorId) {
+        dragSelectionWeakMap.get(workspace).add(element.id);
+        multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
+      }
     }
   });
   connectionDBList.forEach(function(connectionDB) {

--- a/src/global.js
+++ b/src/global.js
@@ -288,6 +288,7 @@ export const cutCallback = (workspace, useCopyPasteCrossTab) => {
       apply(element[0]);
       selected.removeSubDraggable_(element[0]);
     }
+    dragSelection.clear();
   } else {
     apply(selected);
   }
@@ -314,6 +315,7 @@ export const cutCallback = (workspace, useCopyPasteCrossTab) => {
   if (useCopyPasteCrossTab) {
     dataCopyToStorage();
   }
+  Blockly.common.setSelected(null);
   Blockly.Events.setGroup(false);
 };
 

--- a/src/global.js
+++ b/src/global.js
@@ -222,7 +222,7 @@ export const copyCallback = (workspace, useCopyPasteCrossTab) => {
     for (const element of selected.subDraggables) {
       apply(element[0]);
     }
-  } else if (!dragSelection.size) {
+  } else {
     apply(selected);
   }
 
@@ -288,7 +288,7 @@ export const cutCallback = (workspace, useCopyPasteCrossTab) => {
       apply(element[0]);
       selected.removeSubDraggable_(element[0]);
     }
-  } else if (!dragSelection.size) {
+  } else {
     apply(selected);
   }
   dragSelection.clear();

--- a/src/global.js
+++ b/src/global.js
@@ -9,6 +9,7 @@
  */
 
 import * as Blockly from 'blockly/core';
+import { MultiselectDraggable } from './multiselect_draggable';
 
 /**
  * Weakmap for storing multidraggable objects for a given workspace (as a key).
@@ -164,4 +165,237 @@ export const blockNumGetFromStorage = function(useCopyPasteCrossTab) {
     return storage.length;
   }
   return copyData.size;
+};
+
+/**
+ * Check whether element can be copied
+ */
+export const copyCheckCallback = (element) => {
+  if (element instanceof Blockly.BlockSvg) {
+    return element && element.isDeletable() && element.isMovable() &&
+        (element.isInMutator || !hasSelectedParent(element));
+  } else if (element instanceof
+      Blockly.comments.RenderedWorkspaceComment) {
+    return element && element.isDeletable() && element.isMovable();
+  }
+  return false;
+};
+
+/**
+ * Copy selected elements
+ * 
+ * @param {boolean} workspace Workspace this action was triggered on
+ * @param {boolean} useCopyPasteCrossTab Whether or not to use copy/paste
+ */
+export const copyCallback = (workspace, useCopyPasteCrossTab) => {
+  copyData.clear();
+  workspace.hideChaff();
+  const blockList = [];
+  const apply = function(element) {
+    if (copyCheckCallback(element)) {
+      copyData.add(JSON.stringify(element.toCopyData()));
+      if (element instanceof Blockly.BlockSvg) {
+        blockList.push(element.id);
+      }
+    }
+  };
+  const selected = Blockly.common.getSelected();
+  const dragSelection = dragSelectionWeakMap.get(workspace);
+  Blockly.Events.setGroup(true);
+
+  // Handle the case where MultiselectDraggable is in use
+  if (selected && selected instanceof MultiselectDraggable) {
+    for (const element of selected.subDraggables) {
+      apply(element[0]);
+    }
+  } else if (!dragSelection.size) {
+    apply(selected);
+  }
+
+  connectionDBList.length = 0;
+  blockList.forEach(function(id) {
+    const block = workspace.getBlockById(id);
+    const parentBlock = block.getParent();
+    if (parentBlock && blockList.indexOf(parentBlock.id) !== -1 &&
+        parentBlock.getNextBlock() === block) {
+      connectionDBList.push([
+        blockList.indexOf(parentBlock.id),
+        blockList.indexOf(block.id)]);
+    }
+  });
+  if (useCopyPasteCrossTab) {
+    dataCopyToStorage();
+  }
+  Blockly.Events.setGroup(false);
+  return true;
+};
+
+/**
+ * Cut selected elements
+ * 
+ * @param {boolean} workspace Workspace this action was triggered on
+ * @param {boolean} useCopyPasteCrossTab Whether or not to use copy/paste
+ */
+export const cutCallback = (workspace, useCopyPasteCrossTab) => {
+  copyData.clear();
+  const elementList = [];
+  const apply = function(element) {
+    if (copyCheckCallback(element)) {
+      copyData.add(JSON.stringify(element.toCopyData()));
+      elementList.push(element.id);
+    }
+  };
+  const applyDelete = function(element) {
+    if (!element) return;
+    element.workspace.hideChaff();
+    if (element instanceof Blockly.BlockSvg) {
+      if (element.outputConnection) {
+        element.dispose(false, true);
+      } else {
+        element.dispose(true, true);
+      }
+    } else {
+      // This may need to be adjusted based on what
+      // kinds of draggables are added to blockly
+      element.dispose();
+    }
+  };
+
+  const selected = Blockly.common.getSelected();
+  const dragSelection = dragSelectionWeakMap.get(workspace);
+  Blockly.Events.setGroup(true);
+
+  // Handle the case where MultiselectDraggable is in use
+  if (selected && selected instanceof MultiselectDraggable) {
+    for (const element of selected.subDraggables) {
+      apply(element[0]);
+      selected.removeSubDraggable_(element[0]);
+    }
+  } else if (!dragSelection.size) {
+    apply(selected);
+  }
+  dragSelection.clear();
+
+  connectionDBList.length = 0;
+  elementList.forEach(function(id) {
+    const block = workspace.getBlockById(id);
+    if (block) {
+      const parentBlock = block.getParent();
+      if (parentBlock && elementList.indexOf(parentBlock.id) !== -1 &&
+          parentBlock.getNextBlock() === block) {
+        connectionDBList.push([
+          elementList.indexOf(parentBlock.id),
+          elementList.indexOf(block.id)]);
+      }
+    }
+  });
+  elementList.forEach(function(id) {
+    const element = getByID(workspace, id);
+    applyDelete(element);
+  });
+
+  if (useCopyPasteCrossTab) {
+    dataCopyToStorage();
+  }
+  Blockly.Events.setGroup(false);
+};
+
+/**
+ * Paste selected elements
+ * 
+ * @param {boolean} workspace Workspace this action was triggered on
+ * @param {boolean} useCopyPasteCrossTab Whether or not to use copy/paste
+ */
+export const pasteCallback = (workspace, useCopyPasteCrossTab) => {
+  if (workspace.isMutator && workspace.id !== copyMutatorId) {
+    return;
+  }
+
+  inPasteShortcut.set(workspace, true);
+  const dragSelection = dragSelectionWeakMap.get(workspace);
+  const multiDraggable = multiDraggableWeakMap.get(workspace);
+
+  // Update the dragSelection and multiDraggable object
+  // to remove current selection prior to pasting.
+  if (dragSelection?.size) {
+    dragSelection.forEach(function(id) {
+      const element = getByID(workspace, id);
+      if (element) {
+        element.unselect();
+      }
+    });
+    dragSelection.clear();
+    multiDraggable.clearAll_();
+  }
+
+  Blockly.Events.setGroup(true);
+
+  const blockList = [];
+  if (useCopyPasteCrossTab) {
+    dataCopyFromStorage();
+  }
+  const getPasteBlock = function(data, workspace) {
+    const state = data.blockState || data.commentState;
+    const {left, top, width, height} =
+        workspace.getMetricsManager().getViewMetrics(true);
+    const centerCoords = new Blockly.utils.Coordinate(
+        left + width / 2, top + height / 2);
+    const viewportRect = new Blockly.utils.Rect(
+        top, top + height, left, left + width);
+    if (viewportRect.contains(state.x, state.y)) {
+      return Blockly.clipboard.paste(data, workspace);
+    }
+    return Blockly.clipboard.paste(data, workspace, centerCoords);
+  };
+  copyData.forEach(function(stringData) {
+    const data = JSON.parse(stringData);
+    // Set unique id for data to prevent bug where
+    // blocks on multiple workspaces are highlighted.
+    if (workspace.id !== Blockly.getMainWorkspace().id) {
+      if (data.blockState) {
+        data.blockState.id = Blockly.utils.idGenerator.genUid();
+      } else if (data.commentState) {
+        data.commentState.id = Blockly.utils.idGenerator.genUid();
+      }
+    }
+
+    if (data.source) {
+      workspace = data.source;
+    }
+    if (workspace.isFlyout) {
+      workspace = workspace.targetWorkspace;
+    }
+    if (data.typeCounts &&
+        workspace.isCapacityAvailable(data.typeCounts)) {
+      const element = getPasteBlock(data, workspace);
+      if (element) {
+        blockList.push(element);
+      }
+      if (element.type !== 'drag_to_dupe') {
+        dragSelectionWeakMap.get(workspace).add(element.id);
+        multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
+      }
+    } else if (data.commentState) {
+      const element = getPasteBlock(data, workspace);
+      if (element) {
+        element.select();
+      }
+      dragSelectionWeakMap.get(workspace).add(element.id);
+      multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
+    }
+  });
+  connectionDBList.forEach(function(connectionDB) {
+    blockList[connectionDB[0]].nextConnection.connect(
+        blockList[connectionDB[1]].previousConnection);
+  });
+
+  if (!copyMutatorId) {
+    if (dragSelection.size === 1) {
+      Blockly.common.setSelected(getByID(workspace, dragSelection.values().next().value));
+    } else {
+      Blockly.common.setSelected(multiDraggable);
+    }
+  }
+  
+  Blockly.Events.setGroup(false);
 };

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -652,7 +652,7 @@ const registerDelete = function() {
         }
         dragSelection.clear();
         selected.clearAll_();
-      } else if (!dragSelection.size) {
+      } else {
         apply(selected);
       }
 
@@ -945,7 +945,7 @@ const registerCommentDelete = function() {
         }
         dragSelection.clear();
         selected.clearAll_();
-      } else if (!dragSelection.size) {
+      } else {
         apply(scope.comment);
       }
 
@@ -1150,7 +1150,7 @@ const registerCommentCopy = function(useCopyPasteCrossTab) {
             apply(element[0]);
           }
         }
-      } else if (!dragSelection.size) {
+      } else {
         apply(scope.comment);
       }
 

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -13,6 +13,7 @@ import {
   dragSelectionWeakMap, hasSelectedParent, copyData,
   connectionDBList, dataCopyToStorage, dataCopyFromStorage,
   blockNumGetFromStorage, registeredContextMenu, multiDraggableWeakMap, getByID,
+  copyCheckCallback, copyCallback, pasteCallback
 } from './global';
 import {MultiselectDraggable} from './multiselect_draggable';
 
@@ -30,7 +31,7 @@ const registerCopy = function(useCopyPasteCrossTab) {
       const dragSelection = dragSelectionWeakMap.get(workspace);
       dragSelection.forEach(function(id) {
         const block = workspace.getBlockById(id);
-        if (block && copyOptions.check(block)) {
+        if (block && copyCheckCallback(block)) {
           workableBlocksLength++;
         }
       });
@@ -61,7 +62,7 @@ const registerCopy = function(useCopyPasteCrossTab) {
       }
 
       if (!dragSelection.size) {
-        if (copyOptions.check(selected)) {
+        if (copyCheckCallback(selected)) {
           return 'enabled';
         } else {
           return 'disabled';
@@ -69,58 +70,14 @@ const registerCopy = function(useCopyPasteCrossTab) {
       }
       for (const id of dragSelection) {
         const block = workspace.getBlockById(id);
-        if (block && copyOptions.check(block)) {
+        if (block && copyCheckCallback(block)) {
           return 'enabled';
         }
       }
       return 'disabled';
     },
-    check: function(block) {
-      return block && block.isDeletable() && block.isMovable() &&
-             !hasSelectedParent(block);
-    },
     callback: function(scope) {
-      const workspace = scope.block.workspace;
-      copyData.clear();
-      workspace.hideChaff();
-      const blockList = [];
-      const apply = function(block) {
-        if (copyOptions.check(block)) {
-          copyData.add(JSON.stringify(block.toCopyData()));
-          blockList.push(block.id);
-        }
-      };
-      const selected = Blockly.common.getSelected();
-      const dragSelection = dragSelectionWeakMap.get(workspace);
-      Blockly.Events.setGroup(true);
-
-      // Handle the case where MultiselectDraggable is in use
-      if (selected && selected instanceof MultiselectDraggable) {
-        for (const element of selected.subDraggables) {
-          if (element[0] instanceof Blockly.BlockSvg) {
-            apply(element[0]);
-          }
-        }
-      } else if (!dragSelection.size) {
-        apply(selected);
-      }
-
-      connectionDBList.length = 0;
-      blockList.forEach(function(id) {
-        const block = workspace.getBlockById(id);
-        const parentBlock = block.getParent();
-        if (parentBlock && blockList.indexOf(parentBlock.id) !== -1 &&
-          parentBlock.getNextBlock() === block) {
-          connectionDBList.push([
-            blockList.indexOf(parentBlock.id),
-            blockList.indexOf(block.id)]);
-        }
-      });
-      if (useCopyPasteCrossTab) {
-        dataCopyToStorage();
-      }
-      Blockly.Events.setGroup(false);
-      return true;
+      return copyCallback(scope.block.workspace, useCopyPasteCrossTab);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
     id,
@@ -741,77 +698,7 @@ const registerPaste = function(useCopyPasteCrossTab) {
           'disabled': 'enabled');
     },
     callback: function(scope) {
-      let workspace = scope.workspace;
-      const dragSelection = dragSelectionWeakMap.get(workspace);
-      Blockly.Events.setGroup(true);
-      const multiDraggable = multiDraggableWeakMap.get(workspace);
-
-      // Update the dragSelection and multiDraggable object
-      // to remove current selection prior to pasting.
-      if (dragSelection.size) {
-        dragSelection.forEach(function(id) {
-          const element = getByID(workspace, id);
-          element.unselect();
-        });
-        dragSelection.clear();
-        multiDraggable.clearAll_();
-      }
-
-      const blockList = [];
-      if (useCopyPasteCrossTab) {
-        dataCopyFromStorage();
-      }
-      copyData.forEach(function(stringData) {
-        // Pasting always pastes to the main workspace, even if the copy
-        // started in a flyout workspace.
-        const data = JSON.parse(stringData);
-
-        // Set unique id for data to prevent bug where
-        // blocks on multiple workspaces are highlighted.
-        if (workspace.id !== Blockly.getMainWorkspace().id) {
-          if (data.blockState) {
-            data.blockState.id = Blockly.utils.idGenerator.genUid();
-          } else if (data.commentState) {
-            data.commentState.id = Blockly.utils.idGenerator.genUid();
-          }
-        }
-
-        if (data.source) {
-          workspace = data.source;
-        }
-        if (workspace.isFlyout) {
-          workspace = workspace.targetWorkspace;
-        }
-        if (data.typeCounts &&
-            workspace.isCapacityAvailable(data.typeCounts)) {
-          const element = Blockly.clipboard.paste(data, workspace);
-          if (element) {
-            blockList.push(element);
-          }
-          if (element.type !== 'drag_to_dupe') {
-            dragSelectionWeakMap.get(workspace).add(element.id);
-            multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
-          }
-        } else if (data.commentState) {
-          const element = Blockly.clipboard.paste(data, workspace);
-          if (element) {
-            element.select();
-          }
-          dragSelectionWeakMap.get(workspace).add(element.id);
-          multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
-        }
-      });
-      connectionDBList.forEach(function(connectionDB) {
-        blockList[connectionDB[0]].nextConnection.connect(
-            blockList[connectionDB[1]].previousConnection);
-      });
-      Blockly.Events.setGroup(false);
-      if (dragSelection.size === 1) {
-        Blockly.common.setSelected(getByID(workspace, dragSelection.values().next().value));
-      } else {
-        Blockly.common.setSelected(multiDraggable);
-      }
-      return true;
+      return pasteCallback(scope.workspace, useCopyPasteCrossTab);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
     id,
@@ -1189,7 +1076,7 @@ const registerCommentCopy = function(useCopyPasteCrossTab) {
       dragSelection.forEach(function(id) {
         const comment = workspace.getCommentById(id);
         if (comment) {
-          if (copyOptions.check(comment)) {
+          if (copyCheckCallback(comment)) {
             workableCommentsLength++;
           }
         }
@@ -1221,7 +1108,7 @@ const registerCommentCopy = function(useCopyPasteCrossTab) {
       }
 
       if (!dragSelection.size) {
-        if (copyOptions.check(scope.comment)) {
+        if (copyCheckCallback(scope.comment)) {
           return 'enabled';
         } else {
           return 'disabled';
@@ -1230,7 +1117,7 @@ const registerCommentCopy = function(useCopyPasteCrossTab) {
       for (const id of dragSelection) {
         const comment = workspace.getCommentById(id);
         if (comment) {
-          if (copyOptions.check(comment)) {
+          if (copyCheckCallback(comment)) {
             return 'enabled';
           }
         }
@@ -1247,7 +1134,7 @@ const registerCommentCopy = function(useCopyPasteCrossTab) {
       workspace.hideChaff();
 
       const apply = function(comm) {
-        if (copyOptions.check(comm)) {
+        if (copyCheckCallback(comm)) {
           copyData.add(JSON.stringify(comm.toCopyData()));
         }
       };

--- a/src/multiselect_shortcut.js
+++ b/src/multiselect_shortcut.js
@@ -94,7 +94,7 @@ const registerShortcutDelete = function() {
           apply(element[0]);
         }
         dragSelection.clear();
-      } else if (!dragSelection.size) {
+      } {
         apply(selected);
       }
 

--- a/src/multiselect_shortcut.js
+++ b/src/multiselect_shortcut.js
@@ -10,9 +10,10 @@
 
 import * as Blockly from 'blockly/core';
 import {
-  dragSelectionWeakMap, hasSelectedParent, copyData, connectionDBList,
-  dataCopyToStorage, dataCopyFromStorage, registeredShortcut,
-  multiDraggableWeakMap, inPasteShortcut, getByID, shortcutNames,
+  dragSelectionWeakMap, hasSelectedParent, dataCopyToStorage,
+  dataCopyFromStorage, registeredShortcut,
+  multiDraggableWeakMap, getByID, shortcutNames,
+  copyCallback, cutCallback, pasteCallback, copyCheckCallback,
 } from './global';
 import {MultiselectDraggable} from './multiselect_draggable';
 
@@ -129,23 +130,13 @@ const registerCopy = function(useCopyPasteCrossTab) {
       const selected = Blockly.common.getSelected();
       const dragSelection = dragSelectionWeakMap.get(workspace);
       if (!dragSelection.size) {
-        return copyShortcut.check(selected);
+        return copyCheckCallback(selected);
       }
       for (const id of dragSelection) {
         const element = getByID(workspace, id);
-        if (copyShortcut.check(element)) {
+        if (copyCheckCallback(element)) {
           return true;
         }
-      }
-      return false;
-    },
-    check: function(element) {
-      if (element instanceof Blockly.BlockSvg) {
-        return element && element.isDeletable() && element.isMovable() &&
-            !hasSelectedParent(element);
-      } else if (element instanceof
-          Blockly.comments.RenderedWorkspaceComment) {
-        return element && element.isDeletable() && element.isMovable();
       }
       return false;
     },
@@ -153,46 +144,8 @@ const registerCopy = function(useCopyPasteCrossTab) {
       // Prevent the default copy behavior, which may beep or
       // otherwise indicate an error due to the lack of a selection.
       e.preventDefault();
-      copyData.clear();
-      workspace.hideChaff();
-      const blockList = [];
-      const apply = function(element) {
-        if (copyShortcut.check(element)) {
-          copyData.add(JSON.stringify(element.toCopyData()));
-          if (element instanceof Blockly.BlockSvg) {
-            blockList.push(element.id);
-          }
-        }
-      };
-      const selected = Blockly.common.getSelected();
-      const dragSelection = dragSelectionWeakMap.get(workspace);
-      Blockly.Events.setGroup(true);
 
-      // Handle the case where MultiselectDraggable is in use
-      if (selected && selected instanceof MultiselectDraggable) {
-        for (const element of selected.subDraggables) {
-          apply(element[0]);
-        }
-      } else if (!dragSelection.size) {
-        apply(selected);
-      }
-
-      connectionDBList.length = 0;
-      blockList.forEach(function(id) {
-        const block = workspace.getBlockById(id);
-        const parentBlock = block.getParent();
-        if (parentBlock && blockList.indexOf(parentBlock.id) !== -1 &&
-            parentBlock.getNextBlock() === block) {
-          connectionDBList.push([
-            blockList.indexOf(parentBlock.id),
-            blockList.indexOf(block.id)]);
-        }
-      });
-      if (useCopyPasteCrossTab) {
-        dataCopyToStorage();
-      }
-      Blockly.Events.setGroup(false);
-      return true;
+      return copyCallback(workspace, useCopyPasteCrossTab);
     },
   };
   if (name in Blockly.ShortcutRegistry.registry.getRegistry()) {
@@ -233,90 +186,18 @@ const registerCut = function(useCopyPasteCrossTab) {
       const selected = Blockly.common.getSelected();
       const dragSelection = dragSelectionWeakMap.get(workspace);
       if (!dragSelection.size) {
-        return cutShortcut.check(selected);
+        return copyCheckCallback(selected);
       }
       for (const id of dragSelection) {
         const element = getByID(workspace, id);
-        if (cutShortcut.check(element)) {
+        if (copyCheckCallback(element)) {
           return true;
         }
       }
       return false;
     },
-    check: function(element) {
-      if (element instanceof Blockly.BlockSvg) {
-        return element && element.isDeletable() && element.isMovable() &&
-            !element.workspace.isFlyout &&
-            !hasSelectedParent(element);
-      } else if (element instanceof
-          Blockly.comments.RenderedWorkspaceComment) {
-        return element && element.isDeletable() && element.isMovable();
-      }
-      return false;
-    },
     callback: function(workspace) {
-      copyData.clear();
-      const elementList = [];
-      const apply = function(element) {
-        if (cutShortcut.check(element)) {
-          copyData.add(JSON.stringify(element.toCopyData()));
-          elementList.push(element.id);
-        }
-      };
-      const applyDelete = function(element) {
-        if (!element) return;
-        element.workspace.hideChaff();
-        if (element instanceof Blockly.BlockSvg) {
-          if (element.outputConnection) {
-            element.dispose(false, true);
-          } else {
-            element.dispose(true, true);
-          }
-        } else {
-          // This may need to be adjusted based on what
-          // kinds of draggables are added to blockly
-          element.dispose();
-        }
-      };
-
-      const selected = Blockly.common.getSelected();
-      const dragSelection = dragSelectionWeakMap.get(workspace);
-      Blockly.Events.setGroup(true);
-
-      // Handle the case where MultiselectDraggable is in use
-      if (selected && selected instanceof MultiselectDraggable) {
-        for (const element of selected.subDraggables) {
-          apply(element[0]);
-          selected.removeSubDraggable_(element[0]);
-        }
-      } else if (!dragSelection.size) {
-        apply(selected);
-      }
-      dragSelection.clear();
-
-      connectionDBList.length = 0;
-      elementList.forEach(function(id) {
-        const block = workspace.getBlockById(id);
-        if (block) {
-          const parentBlock = block.getParent();
-          if (parentBlock && elementList.indexOf(parentBlock.id) !== -1 &&
-              parentBlock.getNextBlock() === block) {
-            connectionDBList.push([
-              elementList.indexOf(parentBlock.id),
-              elementList.indexOf(block.id)]);
-          }
-        }
-      });
-      elementList.forEach(function(id) {
-        const element = getByID(workspace, id);
-        applyDelete(element);
-      });
-
-      if (useCopyPasteCrossTab) {
-        dataCopyToStorage();
-      }
-      Blockly.Events.setGroup(false);
-      return true;
+      return cutCallback(workspace, useCopyPasteCrossTab);
     },
   };
 
@@ -355,91 +236,7 @@ const registerPaste = function(useCopyPasteCrossTab) {
       return !workspace.options.readOnly && !Blockly.Gesture.inProgress();
     },
     callback: function(workspace) {
-      inPasteShortcut.set(workspace, true);
-      const dragSelection = dragSelectionWeakMap.get(workspace);
-      const multiDraggable = multiDraggableWeakMap.get(workspace);
-
-      // Update the dragSelection and multiDraggable object
-      // to remove current selection prior to pasting.
-      if (dragSelection.size) {
-        dragSelection.forEach(function(id) {
-          const element = getByID(workspace, id);
-          if (element) {
-            element.unselect();
-          }
-        });
-        dragSelection.clear();
-        multiDraggable.clearAll_();
-      }
-
-      Blockly.Events.setGroup(true);
-
-      const blockList = [];
-      if (useCopyPasteCrossTab) {
-        dataCopyFromStorage();
-      }
-      const getPasteBlock = function(data, workspace) {
-        const state = data.blockState || data.commentState;
-        const {left, top, width, height} =
-            workspace.getMetricsManager().getViewMetrics(true);
-        const centerCoords = new Blockly.utils.Coordinate(
-            left + width / 2, top + height / 2);
-        const viewportRect = new Blockly.utils.Rect(
-            top, top + height, left, left + width);
-        if (viewportRect.contains(state.x, state.y)) {
-          return Blockly.clipboard.paste(data, workspace);
-        }
-        return Blockly.clipboard.paste(data, workspace, centerCoords);
-      };
-      copyData.forEach(function(stringData) {
-        const data = JSON.parse(stringData);
-        // Set unique id for data to prevent bug where
-        // blocks on multiple workspaces are highlighted.
-        if (workspace.id !== Blockly.getMainWorkspace().id) {
-          if (data.blockState) {
-            data.blockState.id = Blockly.utils.idGenerator.genUid();
-          } else if (data.commentState) {
-            data.commentState.id = Blockly.utils.idGenerator.genUid();
-          }
-        }
-
-        if (data.source) {
-          workspace = data.source;
-        }
-        if (workspace.isFlyout) {
-          workspace = workspace.targetWorkspace;
-        }
-        if (data.typeCounts &&
-            workspace.isCapacityAvailable(data.typeCounts)) {
-          const element = getPasteBlock(data, workspace);
-          if (element) {
-            blockList.push(element);
-          }
-          if (element.type !== 'drag_to_dupe') {
-            dragSelectionWeakMap.get(workspace).add(element.id);
-            multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
-          }
-        } else if (data.commentState) {
-          const element = getPasteBlock(data, workspace);
-          if (element) {
-            element.select();
-          }
-          dragSelectionWeakMap.get(workspace).add(element.id);
-          multiDraggableWeakMap.get(workspace).addSubDraggable_(element);
-        }
-      });
-      connectionDBList.forEach(function(connectionDB) {
-        blockList[connectionDB[0]].nextConnection.connect(
-            blockList[connectionDB[1]].previousConnection);
-      });
-
-      if (dragSelection.size === 1) {
-        Blockly.common.setSelected(getByID(workspace, dragSelection.values().next().value));
-      } else {
-        Blockly.common.setSelected(multiDraggable);
-      }
-      Blockly.Events.setGroup(false);
-      return true;
+      return pasteCallback(workspace, useCopyPasteCrossTab);
     },
   };
 

--- a/test-e2e/actions/multiselect/workspace/block.spec.ts
+++ b/test-e2e/actions/multiselect/workspace/block.spec.ts
@@ -263,9 +263,9 @@ test("drag blocks to trash", async ({ page, act }) => {
 	expect(await getSelectedId(page)).toBe(await getMultiselectDraggableId(page));
 
 	await openTrash(page);
-	await getBlock(page, { type: "logic_boolean", workspace: "trash" });
-	await getBlock(page, { type: "math_arithmetic", workspace: "trash" });
-	await getBlock(page, { type: "logic_compare", workspace: "trash" });
+	await getBlock(page, { type: "logic_boolean", scope: "top", workspace: { name: "trash" } });
+	await getBlock(page, { type: "math_arithmetic", scope: "top", workspace: { name: "trash" } });
+	await getBlock(page, { type: "logic_compare", scope: "top", workspace: { name: "trash" } });
 });
 
 test("drag blocks to backpack", async ({ page, act }) => {
@@ -305,12 +305,12 @@ test("drag blocks to backpack", async ({ page, act }) => {
 	expect(block3BoundsEnd.top).toBeCloseTo(block3BoundsStart.top);
 
 	await openBackpack(page);
-	await getBlock(page, { type: "logic_boolean", workspace: "backpack" });
-	await getBlock(page, { type: "math_arithmetic", workspace: "backpack" });
-	await getBlock(page, { type: "logic_compare", workspace: "backpack" });
+	await getBlock(page, { type: "logic_boolean", scope: "top", workspace: { name: "backpack" } });
+	await getBlock(page, { type: "math_arithmetic", scope: "top", workspace: { name: "backpack" } });
+	await getBlock(page, { type: "logic_compare", scope: "top", workspace: { name: "backpack" } });
 	await expect(
-		getBlock(page, { type: "math_number", workspace: "backpack" }),
-	).rejects.toThrow('Block type "math_number" not found');
+		getBlock(page, { type: "math_number", scope: "top", workspace: { name: "backpack" } }),
+	).rejects.toThrow("Block not found");
 });
 
 test("undo via keyboard", async ({ page, act }) => {

--- a/test-e2e/actions/multiselect/workspace/block.spec.ts
+++ b/test-e2e/actions/multiselect/workspace/block.spec.ts
@@ -250,6 +250,116 @@ test("delete blocks via context menu", async ({ page, act }) => {
 	expect(await getSelectedId(page)).toBeNull();
 });
 
+test("single multiselect block delete via keyboard", async ({ page, act }) => {
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "block1" })).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["block1"]);
+	expect(await getSelectedId(page)).toBe("block1");
+
+	await act(page.keyboard.press("Delete"));
+
+	expect(await getAllBlockIds(page)).toEqual([
+		"block2",
+		"block2-child",
+		"block3",
+		"block3-child",
+		"block4",
+	]);
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+	expect(await getSelectedId(page)).toBeNull();
+});
+
+test("single multiselect block copy/paste via keyboard", async ({ page, act }) => {
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "block1" })).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getHighlightedBlockIds(page)).toEqual(["block1"]);
+	expect(await getSelectedId(page)).toBe("block1");
+
+	await act(page.keyboard.press("ControlOrMeta+C"));
+
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+
+	await act(page.keyboard.press("ControlOrMeta+V"));
+
+	const allBlockIds = await getAllBlockIds(page);
+	expect(allBlockIds).toHaveLength(7);
+
+	const newBlockId = allBlockIds.find(
+		(id) =>
+			![
+				"block1",
+				"block2",
+				"block2-child",
+				"block3",
+				"block3-child",
+				"block4",
+			].includes(id),
+	);
+	expect(newBlockId).toBeDefined();
+	expect(await getHighlightedBlockIds(page)).toEqual([newBlockId!]);
+	expect(await getSelectedId(page)).toBe(newBlockId);
+});
+
+test("single multiselect block cut/paste via keyboard", async ({ page, act }) => {
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getBlock(page, { id: "block1" })).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getAllBlockIds(page)).toEqual([
+		"block1",
+		"block2",
+		"block2-child",
+		"block3",
+		"block3-child",
+		"block4",
+	]);
+	expect(await getHighlightedBlockIds(page)).toEqual(["block1"]);
+	expect(await getSelectedId(page)).toBe("block1");
+
+	await act(page.keyboard.press("ControlOrMeta+X"));
+
+	expect(await getAllBlockIds(page)).toEqual([
+		"block2",
+		"block2-child",
+		"block3",
+		"block3-child",
+		"block4",
+	]);
+	expect(await getHighlightedBlockIds(page)).toEqual([]);
+	expect(await getSelectedId(page)).toBeNull();
+
+	await act(page.keyboard.press("ControlOrMeta+V"));
+
+	expect(await getAllBlockIds(page)).toEqual([
+		"block1",
+		"block2",
+		"block2-child",
+		"block3",
+		"block3-child",
+		"block4",
+	]);
+	expect(await getHighlightedBlockIds(page)).toEqual(["block1"]);
+	expect(await getSelectedId(page)).toBe("block1");
+});
+
 test("drag blocks to trash", async ({ page, act }) => {
 	await act(
 		page.mouse.move(...(await getBlock(page, { id: "block1" })).centerTop),

--- a/test-e2e/actions/multiselect/workspace/comment.spec.ts
+++ b/test-e2e/actions/multiselect/workspace/comment.spec.ts
@@ -216,6 +216,90 @@ test("undo via context menu", async ({ page, act }) => {
 	]);
 });
 
+test("single multiselect comment delete via keyboard", async ({ page, act }) => {
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+	expect(await getHighlightedCommentIds(page)).toEqual([]);
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getComment(page, "comment1")).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getHighlightedCommentIds(page)).toEqual(["comment1"]);
+	expect(await getSelectedId(page)).toBe("comment1");
+
+	await act(page.keyboard.press("Delete"));
+
+	expect(await getAllCommentIds(page)).toEqual(["comment2", "comment3"]);
+	expect(await getHighlightedCommentIds(page)).toEqual([]);
+	expect(await getSelectedId(page)).toBeNull();
+});
+
+test("single multiselect comment copy/paste via keyboard", async ({ page, act }) => {
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getComment(page, "comment1")).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getHighlightedCommentIds(page)).toEqual(["comment1"]);
+	expect(await getSelectedId(page)).toBe("comment1");
+
+	await act(page.keyboard.press("ControlOrMeta+C"));
+
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+	expect(await getHighlightedCommentIds(page)).toEqual([]);
+
+	await act(page.keyboard.press("ControlOrMeta+V"));
+
+	const allCommentIds = await getAllCommentIds(page);
+	expect(allCommentIds).toHaveLength(4);
+
+	const newCommentId = allCommentIds.find(
+		(id) => !["comment1", "comment2", "comment3"].includes(id),
+	);
+	expect(newCommentId).toBeDefined();
+	expect(await getHighlightedCommentIds(page)).toEqual([newCommentId!]);
+	expect(await getSelectedId(page)).toBe(newCommentId);
+});
+
+test("single multiselect comment cut/paste via keyboard", async ({ page, act }) => {
+	await act(page.mouse.click(...(await getEmptySpace(page))));
+
+	await act(page.keyboard.down("Shift"));
+	await act(
+		page.mouse.click(...(await getComment(page, "comment1")).centerTop),
+	);
+	await act(page.keyboard.up("Shift"));
+
+	expect(await getAllCommentIds(page)).toEqual([
+		"comment1",
+		"comment2",
+		"comment3",
+	]);
+	expect(await getHighlightedCommentIds(page)).toEqual(["comment1"]);
+	expect(await getSelectedId(page)).toBe("comment1");
+
+	await act(page.keyboard.press("ControlOrMeta+X"));
+
+	expect(await getAllCommentIds(page)).toEqual(["comment2", "comment3"]);
+	expect(await getHighlightedCommentIds(page)).toEqual([]);
+	expect(await getSelectedId(page)).toBeNull();
+
+	await act(page.keyboard.press("ControlOrMeta+V"));
+
+	expect(await getAllCommentIds(page)).toEqual([
+		"comment1",
+		"comment2",
+		"comment3",
+	]);
+	expect(await getHighlightedCommentIds(page)).toEqual(["comment1"]);
+	expect(await getSelectedId(page)).toBe("comment1");
+});
+
 test("drag comments", async ({ page, act }) => {
 	const gridSpacing = await getGridSpacing(page);
 	if (gridSpacing === null) throw new Error("Workspace has no grid");

--- a/test-e2e/actions/select/workspace/block.spec.ts
+++ b/test-e2e/actions/select/workspace/block.spec.ts
@@ -139,7 +139,7 @@ test("drag block to trash", async ({ page, act }) => {
 	expect(await getSelectedId(page)).toBe("block1");
 
 	await openTrash(page);
-	await getBlock(page, { type: "logic_boolean", workspace: "trash" });
+	await getBlock(page, { type: "logic_boolean", scope: "top", workspace: { name: "trash" } });
 });
 
 test("drag block from trash", async ({ page, act }) => {
@@ -149,7 +149,7 @@ test("drag block from trash", async ({ page, act }) => {
 	await openTrash(page);
 	await act(
 		page.mouse.move(
-			...(await getBlock(page, { type: "logic_boolean", workspace: "trash" }))
+			...(await getBlock(page, { type: "logic_boolean", scope: "top", workspace: { name: "trash" } }))
 				.centerTop,
 		),
 	);
@@ -181,7 +181,7 @@ test("drag block to backpack", async ({ page, act }) => {
 	expect(block1BoundsEnd.top).toBe(block1BoundsStart.top);
 
 	await openBackpack(page);
-	await getBlock(page, { type: "logic_boolean", workspace: "backpack" });
+	await getBlock(page, { type: "logic_boolean", scope: "top", workspace: { name: "backpack" } });
 });
 
 test("drag block from backpack", async ({ page, act }) => {
@@ -198,7 +198,7 @@ test("drag block from backpack", async ({ page, act }) => {
 			...(
 				await getBlock(page, {
 					type: "logic_boolean",
-					workspace: "backpack",
+					scope: "top", workspace: { name: "backpack" },
 				})
 			).centerTop,
 		),
@@ -278,7 +278,7 @@ test("dragging block from toolbox selects new block", async ({ page, act }) => {
 	expect(await getSelectedId(page)).toBe("block1");
 	await act(
 		page.mouse.move(
-			...(await getBlock(page, { type: "controls_if", workspace: "toolbox" }))
+			...(await getBlock(page, { type: "controls_if", scope: "top", workspace: { name: "toolbox" } }))
 				.centerTop,
 		),
 	);

--- a/test-e2e/actions/select/workspace/mutator.spec.ts
+++ b/test-e2e/actions/select/workspace/mutator.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from "@playwright/test";
+import {
+  getAllBlockIds,
+  getBlock,
+  getHighlightedBlockIds,
+  getSelectedId,
+  loadBlocks,
+  openMutator,
+  test,
+} from "../../../test";
+
+test.beforeEach(async ({ page, act }) => {
+  await act(
+    loadBlocks(page, [
+      {
+        type: "procedures_defreturn",
+        id: "block1",
+        extraState: {
+          params: [{ name: "param1", id: "param1" }],
+        },
+      },
+    ]),
+  );
+  await act(openMutator(page, "block1"));
+  
+  const mutatorBlock = await getBlock(page, {
+    workspace: { name: "mutator", mutatorOf: { id: "block1" } },
+    type: "procedures_mutatorarg",
+  });
+  await act(page.mouse.click(...mutatorBlock.centerTop));
+});
+
+test("copy and paste mutator block via keyboard", async ({ page, act }) => {
+  const mutatorBlockIds = await getAllBlockIds(page, {
+    workspace: { name: "mutator", mutatorOf: { id: "block1" } },
+  });
+  const selectedMutatorBlockIds = await getHighlightedBlockIds(page, {
+    workspace: { name: "mutator", mutatorOf: { id: "block1" } },
+  });
+  
+  expect(await getAllBlockIds(page)).toEqual(["block1"]);
+  expect(mutatorBlockIds).toHaveLength(2);
+  expect(selectedMutatorBlockIds).toHaveLength(1);
+  expect(await getSelectedId(page)).toBe(selectedMutatorBlockIds[0]);
+
+  await act(page.keyboard.press('ControlOrMeta+c'));
+  await act(page.keyboard.press('ControlOrMeta+v'));
+  
+  const allMutatorBlockIds = await getAllBlockIds(page, {
+    workspace: { name: "mutator", mutatorOf: { id: "block1" } },
+  });
+  
+  expect(await getAllBlockIds(page)).toEqual(["block1"]);
+  expect(allMutatorBlockIds).toHaveLength(3);
+  
+  const newMutatorBlockId = allMutatorBlockIds.find(
+    (id) => !mutatorBlockIds.includes(id)
+  );
+  expect(newMutatorBlockId).toBeDefined();
+
+  expect(
+    await getHighlightedBlockIds(page, {
+      workspace: { name: "mutator", mutatorOf: { id: "block1" } },
+    }),
+  ).toEqual([newMutatorBlockId!]);
+  
+  expect(await getSelectedId(page)).toBe(newMutatorBlockId);
+});
+
+test("paste after closing mutator does nothing in main workspace", async ({
+  page,
+  act,
+}) => {
+  const initialMainBlockIds = await getAllBlockIds(page);
+  
+  await act(page.keyboard.press('ControlOrMeta+c'));
+  
+  await act(page.locator(`g[data-id="block1"] .blockly-icon-mutator`).click());
+  
+  await page.waitForFunction(
+    (blockId) => {
+      const workspace = (window as any).Blockly.getMainWorkspace();
+      const block = workspace.getBlockById(blockId);
+      if (!block) return true;
+      const mutatorIcon = block.getIcon((window as any).Blockly.icons.IconType.MUTATOR);
+      return !mutatorIcon || !mutatorIcon.bubbleIsVisible();
+    },
+    "block1",
+  );
+
+  await act(page.mouse.click(100, 100)); 
+  await act(page.keyboard.press('ControlOrMeta+v'));
+  
+  expect(await getAllBlockIds(page)).toEqual(initialMainBlockIds);
+});
+
+test("paste after page reload does nothing", async ({ page, act }) => {
+  const initialMainBlockIds = await getAllBlockIds(page);
+  
+  await act(page.keyboard.press('ControlOrMeta+c'));
+  
+  await page.reload();
+  await page.locator(".blocklySvg").hover();
+  
+  await act(page.keyboard.press('ControlOrMeta+v'));
+  
+  expect(await getAllBlockIds(page)).toEqual(initialMainBlockIds);
+});
+

--- a/test-e2e/test.ts
+++ b/test-e2e/test.ts
@@ -3,6 +3,7 @@ import { test as base, type Page } from "@playwright/test";
 import type {
 	comments,
 	IComponent,
+	icons,
 	serialization,
 	WorkspaceSvg,
 } from "blockly";
@@ -17,18 +18,30 @@ declare global {
 	}
 }
 
+type BlockSelector =
+	| { id: string; type?: never; scope?: never }
+	| { type: string; scope?: "all" | "top"; id?: never };
+
+type WorkspaceSelector =
+	| { name: "main"; mutatorOf?: never }
+	| { name: "toolbox"; mutatorOf?: never }
+	| { name: "trash"; mutatorOf?: never }
+	| { name: "backpack"; mutatorOf?: never }
+	| { name: "mutator"; mutatorOf: BlockSelector };
+
+type BlocksQuery = { workspace?: WorkspaceSelector; block?: BlockSelector };
+type BlockQuery = { workspace?: WorkspaceSelector } & BlockSelector;
+
 type Act = (action: Promise<void>) => Promise<void>;
-type BlockQuery = { workspace?: "main" | "toolbox" | "trash" | "backpack" } & (
-	| { id: string; type?: never }
-	| { type: string; id?: never }
-);
 type Point = [number, number];
 type Bounds = { top: number; bottom: number; left: number; right: number };
 type FieldJSON = { center: Point; value: unknown | null };
 type BlockJSON = {
+	id: string;
 	centerTop: Point;
 	bounds: Bounds;
 	isCollapsed: boolean;
+	isHighlighted: boolean;
 	hasComment: boolean;
 	hasInlineInputs: boolean;
 	isEnabled: boolean;
@@ -94,11 +107,26 @@ export const loadBlocks = (
 		workspace.cleanUp();
 	}, blocks);
 
-export const getBlock = (page: Page, query: BlockQuery): Promise<BlockJSON> =>
-	page.evaluate((query: BlockQuery) => {
+export const getBlocks = (
+	page: Page,
+	query: BlocksQuery = {},
+): Promise<BlockJSON[]> =>
+	page.evaluate((query: BlocksQuery) => {
+		const getBlockFromWorkspace = (
+			workspace: WorkspaceSvg,
+			selector: BlockSelector,
+		) =>
+			selector.id
+				? workspace.getBlockById(selector.id)
+				: (selector.scope === "top"
+						? workspace.getTopBlocks()
+						: workspace.getAllBlocks()
+					).find((b) => b.type === selector.type);
+
 		const mainWorkspace = Blockly.getMainWorkspace() as WorkspaceSvg;
+		const workspaceSelector = query.workspace ?? { name: "main" };
 		let workspace: WorkspaceSvg;
-		switch (query.workspace ?? "main") {
+		switch (workspaceSelector.name) {
 			case "main":
 				workspace = mainWorkspace;
 				break;
@@ -125,80 +153,109 @@ export const getBlock = (page: Page, query: BlockQuery): Promise<BlockJSON> =>
 				workspace = flyout.getWorkspace();
 				break;
 			}
-			default:
-				throw new Error(`Workspace "${query.workspace}" not found`);
-		}
-		const block = query.id
-			? workspace.getBlockById(query.id)
-			: workspace.getTopBlocks().find((b) => b.type === query.type);
-		if (!block)
-			throw new Error(
-				`Block ${query.id ? `"${query.id}"` : `type "${query.type}"`} not found`,
-			);
-		const workspaceBounds = block.getBoundingRectangleWithoutChildren();
-		const topLeft = Blockly.utils.svgMath.wsToScreenCoordinates(
-			workspace,
-			new Blockly.utils.Coordinate(workspaceBounds.left, workspaceBounds.top),
-		);
-		const bottomRight = Blockly.utils.svgMath.wsToScreenCoordinates(
-			workspace,
-			new Blockly.utils.Coordinate(
-				workspaceBounds.right,
-				workspaceBounds.bottom,
-			),
-		);
-		const bounds = {
-			top: topLeft.y,
-			bottom: bottomRight.y,
-			left: topLeft.x,
-			right: bottomRight.x,
-		};
-		const centerTop: Point = [(bounds.left + bounds.right) / 2, bounds.top + 1];
-		const fields: Record<string, FieldJSON> = {};
-		for (const input of block.inputList) {
-			for (const field of input.fieldRow) {
-				if (!field.name) continue;
-				const svgRoot = field.getSvgRoot();
-				if (!svgRoot) continue;
-				const fieldBounds = svgRoot.getBoundingClientRect();
-				fields[field.name] = {
-					center: [
-						(fieldBounds.left + fieldBounds.right) / 2,
-						(fieldBounds.top + fieldBounds.bottom) / 2,
-					],
-					value: field.getValue(),
-				};
+			case "mutator": {
+				const mutatorSourceBlock = getBlockFromWorkspace(
+					mainWorkspace,
+					workspaceSelector.mutatorOf,
+				);
+				if (!mutatorSourceBlock)
+					throw new Error("Mutator source block not found");
+				const mutatorIcon = mutatorSourceBlock.getIcon<icons.MutatorIcon>(
+					Blockly.icons.IconType.MUTATOR,
+				);
+				if (!mutatorIcon) throw new Error("Mutator icon not found");
+				const mutatorWorkspace = mutatorIcon.getWorkspace();
+				if (!mutatorWorkspace) throw new Error("Mutator workspace not found");
+				workspace = mutatorWorkspace;
+				break;
 			}
+			default:
+				throw new Error(`Workspace "${(workspaceSelector as any).name}" not found`);
 		}
-		return {
-			centerTop,
-			bounds,
-			isCollapsed: block.isCollapsed(),
-			hasComment: block.hasIcon(Blockly.icons.CommentIcon.TYPE),
-			hasInlineInputs: block.getInputsInline(),
-			isEnabled: block.isEnabled(),
-			fields,
-		};
+		const blocks = query.block
+			? [getBlockFromWorkspace(workspace, query.block)].filter((block) => !!block)
+			: workspace.getAllBlocks();
+		return blocks.map((block) => {
+			const workspaceBounds = block.getBoundingRectangleWithoutChildren();
+			const topLeft = Blockly.utils.svgMath.wsToScreenCoordinates(
+				workspace,
+				new Blockly.utils.Coordinate(workspaceBounds.left, workspaceBounds.top),
+			);
+			const bottomRight = Blockly.utils.svgMath.wsToScreenCoordinates(
+				workspace,
+				new Blockly.utils.Coordinate(
+					workspaceBounds.right,
+					workspaceBounds.bottom,
+				),
+			);
+			const bounds = {
+				top: topLeft.y,
+				bottom: bottomRight.y,
+				left: topLeft.x,
+				right: bottomRight.x,
+			};
+			const centerTop: Point = [(bounds.left + bounds.right) / 2, bounds.top + 1];
+			const fields: Record<string, FieldJSON> = {};
+			for (const input of block.inputList) {
+				for (const field of input.fieldRow) {
+					if (!field.name) continue;
+					const svgRoot = field.getSvgRoot();
+					if (!svgRoot) continue;
+					const fieldBounds = svgRoot.getBoundingClientRect();
+					fields[field.name] = {
+						center: [
+							(fieldBounds.left + fieldBounds.right) / 2,
+							(fieldBounds.top + fieldBounds.bottom) / 2,
+						],
+						value: field.getValue(),
+					};
+				}
+			}
+			return {
+				id: block.id,
+				centerTop,
+				bounds,
+				isCollapsed: block.isCollapsed(),
+				isHighlighted: block.getSvgRoot().classList.contains("blocklySelected"),
+				hasComment: block.hasIcon(Blockly.icons.CommentIcon.TYPE),
+				hasInlineInputs: block.getInputsInline(),
+				isEnabled: block.isEnabled(),
+				fields,
+			};
+		});
 	}, query);
 
-export const getAllBlockIds = (page: Page): Promise<string[]> =>
-	page.evaluate(() =>
-		(Blockly.getMainWorkspace() as WorkspaceSvg)
-			.getAllBlocks()
-			.map((block) => block.id)
-			.sort(),
-	);
+export const getBlock = async (
+	page: Page,
+	query: BlockQuery,
+): Promise<BlockJSON> => {
+	const blocks = await getBlocks(page, {
+		workspace: query.workspace,
+		block: query,
+	});
+	if (blocks.length === 0) throw new Error("Block not found");
+	if (blocks.length > 1) throw new Error("Expected one block, found multiple");
+	return blocks[0];
+};
 
-export const getHighlightedBlockIds = (page: Page): Promise<string[]> =>
-	page.evaluate(() =>
-		(Blockly.getMainWorkspace() as WorkspaceSvg)
-			.getAllBlocks()
-			.filter((block) =>
-				block.getSvgRoot().classList.contains("blocklySelected"),
-			)
-			.map((block) => block.id)
-			.sort(),
-	);
+export const getAllBlockIds = (
+  page: Page,
+  query: BlocksQuery = {},  // <-- ADD PARAMETER
+): Promise<string[]> =>
+  getBlocks(page, query).then((blocks) =>
+    blocks.map((block) => block.id).sort(),
+  );
+
+export const getHighlightedBlockIds = (
+  page: Page,
+  query: BlocksQuery = {},  // <-- ADD PARAMETER
+): Promise<string[]> =>
+  getBlocks(page, query).then((blocks) =>
+    blocks
+      .filter((block) => block.isHighlighted)  // <-- USE NEW FIELD
+      .map((block) => block.id)
+      .sort(),
+  );
 
 export const loadComments = (
 	page: Page,
@@ -347,6 +404,24 @@ export const openBackpack = async (page: Page): Promise<void> => {
 		if (!backpack) throw new Error("Backpack not found");
 		backpack.open();
 	});
+};
+
+export const openMutator = async (
+  page: Page,
+  blockId: string,
+): Promise<void> => {
+  await page.locator(`g[data-id="${blockId}"] .blockly-icon-mutator`).click();
+  await page.waitForFunction(
+    (blockId) => {
+      const workspace = Blockly.getMainWorkspace() as WorkspaceSvg;
+      const block = workspace.getBlockById(blockId);
+      if (!block) return false;
+      const mutatorIcon = block.getIcon(Blockly.icons.IconType.MUTATOR);
+      if (!mutatorIcon) return false;
+      return mutatorIcon.bubbleIsVisible();
+    },
+    blockId,
+  );
 };
 
 export const isMultiselectEnabled = (page: Page): Promise<boolean> =>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #136 and #143

### Proposed Changes

1) Moved copy/paste callbacks to shared functions in `global.js`. They should ideally behave exactly the same and creating shared functions ensures that (fixes "paste into visible area" not working with paste by context menu)
2) Added `copyMutatorId` variable that tracks if last elements were copied from mutator workspace and its id. If this variable is present, then we try to find workspace by id and insert elements there
3) Updated `dataCopyToStorage` to never save mutator blocks in the storage. Now nothing will be saved in the storage if you copy mutator blocks
4) Fixed minor issue with cut/delete inconsistency. Cut shortcut was not deselecting destroyed elements
5) Replaced `if (selected instanceof MultiselectDraggable) else if (!dragSelection.size)` check to a simple `if (selected instanceof MultiselectDraggable) else`. `!dragSelection.size` check was ignoring the fact that single block in dragSelection is not wrapped inside MultiselectDraggable
6) Updated test helpers to support mutator workspaces and top/all block selectors (To be fair, I just copied code from `[cd0718e](https://github.com/mit-cml/workspace-multiselect/commit/cd0718ee70c6e35ca57e85a6412e4123a2dadd85)` by @mjgallag. Thanks for making it!)

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

1) Shared function ensures consistency between behaviours. It won't be necessary to keep both contextmenu and shortcuts in sync. (Although I can revert this commit, if necessary)
2) `copyMutatorId` variables allows copy/paste inside mutator blocks, a feature original Blockly supports. Also fixes the bug when mutator blocks can end up in the main workspace breaking code generation and possibly even deserialization
3) Mutator blocks are never saved in the storage so they can't be pasted on page reload
4) Cut shortcut now removes selection from deleted elements for consistency with delete shortcut
5) Removing `!dragSelection.size` check aligns with multiselect logic - drag selection with size 1 is not wrapped in MultiselectDragging
6) Test helpers update was required for mutator blocks testing

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

1) Added mutator.spec.ts file that tests mutators behaviour with copy/paste. Mutator blocks only support single selection, so file is inside `select` folder
2) Added tests for multiselecting single block/comment and performing actions on them
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

N/A
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I did both issues in this pull request, because I've moved copy/paste logic and wanted to avoid merge conflicts. Hope that's not a problem!
<!-- Anything else we should know? -->
