### PR TITLE
Implement option to add only selected items to backpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ options = {
     // Show the copy/paste menu entries (true by default).
     menu: true,
   },
+
+  // Enable backpacking selected blocks as a single unit when possible
+  // And avoid saving not selected blocks
+  backpackOnlySelected: false,
 };
 
 // Inject Blockly.

--- a/src/multiselect.js
+++ b/src/multiselect.js
@@ -42,6 +42,7 @@ export class Multiselect {
     this.multiFieldUpdate_ = true;
     this.multiSelectKeys_ = ['shift'];
     this.registeredShortcut_ = true;
+    this.backpackOnlySelected_ = true;
   }
 
   /**
@@ -109,10 +110,14 @@ export class Multiselect {
       this.useCopyPasteMenu_ = false;
     }
 
+    if (!options.backpackOnlySelected) {
+      this.backpackOnlySelected_ = false;
+    }
+
     if (!Blockly.ContextMenuRegistry.registry.getItem('workspaceSelectAll')) {
       ContextMenu.unregisterContextMenu();
       ContextMenu.registerOurContextMenu(this.useCopyPasteMenu_,
-          this.useCopyPasteCrossTab_);
+          this.useCopyPasteCrossTab_, this.backpackOnlySelected_);
       Shortcut.unregisterOrigShortcut();
       Shortcut.registerOurShortcut(this.useCopyPasteCrossTab_);
     }

--- a/src/multiselect_contextmenu.js
+++ b/src/multiselect_contextmenu.js
@@ -891,11 +891,11 @@ const registerSelectAll = function() {
 
 /**
  * Registers copy to back pack context menu item in back pack.
- * @param {boolean} disablePreconditionContainsCheck Option for
- *                  the back pack plugin, default is false.
+ * @param {boolean} backpackOnlySelected Option for
+ *                  adding only selected items. Default is false
  */
 const updateToMultiCopyToBackpack =
-    function(disablePreconditionContainsCheck = false) {
+    function(backpackOnlySelected = false) {
       const id = 'copy_to_backpack';
       const copyToBackpack = {
         getBackPack: function(ws) {
@@ -911,6 +911,91 @@ const updateToMultiCopyToBackpack =
              !backpack.containsBlock(block) &&
              !hasSelectedParent(block);
         },
+        cleanFlyoutInfo: function(dirtyInfo) {
+          // The keys to remove.
+          const removeKeys = [
+            'id',
+            'height',
+            'width',
+            'pinned',
+            'enabled',
+            //'disabledReasons',
+          ];
+
+          // Traverse the object recursively.
+          const traverseClean = function (obj, keys) {
+            for (const key of Object.keys(obj)) {
+              if (keys.indexOf(key) !== -1) {
+                delete obj[key];
+                continue;
+              }
+
+              const item = obj[key];
+              if (item !== null && typeof item === 'object') {
+                traverseClean(item, keys);
+              }
+            }
+          };
+
+          traverseClean(dirtyInfo, removeKeys);
+        },
+        getMultiselectedBlocksForBackpack(blocks) {
+          const allBlocksIds = new Set(blocks.map((block) => block.id));
+          const rootBlocks = new Set(blocks);
+
+          blocks.forEach((block) => {
+            const prevBlock = block.getPreviousBlock();
+            if (prevBlock && allBlocksIds.has(prevBlock.id)) {
+              // Parent will be in the list
+              rootBlocks.delete(block);
+              return;
+            }
+
+            let parent = block.getSurroundParent();
+            while (parent?.getSurroundParent()) {
+              if (allBlocksIds.has(parent.id)) {
+                // Parent will be in the list
+                rootBlocks.delete(block);
+                return;
+              }
+
+              parent = parent.getSurroundParent();
+            }
+          })
+
+          const blocksInfo = [];
+          rootBlocks.forEach((block) => {
+            const json = Blockly.serialization.blocks.save(block);
+            if (json) {
+              let currentBlock = json;
+
+              while (currentBlock) {
+                let nextBlock = currentBlock?.next?.block;
+                if (nextBlock) {
+                  const id = nextBlock.id;
+                  if (id && !allBlocksIds.has(id)) {
+                    // Block is not selected. We do not add it
+                    delete currentBlock.next;
+                    nextBlock = null;
+                  }
+                }
+
+                currentBlock = nextBlock;
+              }
+
+              let modifiedJson = {
+                kind: 'BLOCK',
+                ...json,
+              };
+
+              copyToBackpack.cleanFlyoutInfo(modifiedJson);
+
+              blocksInfo.push(JSON.stringify(modifiedJson));
+            }
+          });
+
+          return blocksInfo;
+        },
         displayText: function(scope) {
           if (!scope.block) {
             return '';
@@ -922,16 +1007,30 @@ const updateToMultiCopyToBackpack =
           }
           let workableBlocksLength = 0;
           const dragSelection = dragSelectionWeakMap.get(ws);
+          
+          const blocksToAdd = [];
           if (!dragSelection.size) {
             if (copyToBackpack.check(scope.block)) {
-              workableBlocksLength++;
+              blocksToAdd.push(scope.block);
+            }
+          } else {
+            dragSelection.forEach((id) => {
+              const block = ws.getBlockById(id);
+              if (copyToBackpack.check(block)) {
+                blocksToAdd.push(block);
+              }
+            });
+
+            if (blocksToAdd.length > 0) {
+              if (backpackOnlySelected) {
+                const backpackBlocks = copyToBackpack.getMultiselectedBlocksForBackpack(blocksToAdd);
+                workableBlocksLength = backpackBlocks.length;
+              } else {
+                workableBlocksLength = blocksToAdd.length;
+              }
             }
           }
-          for (const id of dragSelection) {
-            if (copyToBackpack.check(ws.getBlockById(id))) {
-              workableBlocksLength++;
-            }
-          }
+          
           if (workableBlocksLength > 1) {
             if (Blockly.Msg['COPY_X_TO_BACKPACK']) {
               return Blockly.Msg['COPY_X_TO_BACKPACK']
@@ -950,9 +1049,6 @@ const updateToMultiCopyToBackpack =
           if (!ws.isFlyout) {
             if (!copyToBackpack.getBackPack(ws)) {
               return 'hidden';
-            }
-            if (disablePreconditionContainsCheck) {
-              return 'enabled';
             }
             const dragSelection = dragSelectionWeakMap.get(ws);
             if (!dragSelection.size) {
@@ -974,17 +1070,29 @@ const updateToMultiCopyToBackpack =
           const ws = scope.block.workspace;
           const backpack = copyToBackpack.getBackPack(ws);
           const dragSelection = dragSelectionWeakMap.get(ws);
+
+          const blocksToAdd = [];
           if (!dragSelection.size) {
             if (copyToBackpack.check(scope.block)) {
-              backpack.addBlock(scope.block);
+              blocksToAdd.push(scope.block);
+            }
+          } else {
+            dragSelection.forEach((id) => {
+              const block = ws.getBlockById(id);
+              if (copyToBackpack.check(block)) {
+                blocksToAdd.push(block);
+              }
+            });
+          }
+
+          if (blocksToAdd.length > 0) {
+            if (backpackOnlySelected) {
+              const backpackBlocks = copyToBackpack.getMultiselectedBlocksForBackpack(blocksToAdd);
+              backpack.addItems(backpackBlocks);
+            } else {
+              backpack.addBlocks(blocksToAdd);
             }
           }
-          dragSelection.forEach(function(id) {
-            const block = ws.getBlockById(id);
-            if (copyToBackpack.check(block)) {
-              backpack.addBlock(block);
-            }
-          });
         },
         scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
         id,
@@ -1322,7 +1430,7 @@ export const registerOrigContextMenu = function() {
  * @param {boolean} useCopyPasteMenu Whether to use copy/paste menu.
  * @param {boolean} useCopyPasteCrossTab Whether to use cross tab copy/paste.
  */
-export const registerOurContextMenu = function(useCopyPasteMenu, useCopyPasteCrossTab) {
+export const registerOurContextMenu = function(useCopyPasteMenu, useCopyPasteCrossTab, backpackOnlySelected) {
   if (useCopyPasteMenu) {
     registerCopy(useCopyPasteCrossTab);
     registerPaste(useCopyPasteCrossTab);
@@ -1342,5 +1450,5 @@ export const registerOurContextMenu = function(useCopyPasteMenu, useCopyPasteCro
     map[id]();
   }
   registerSelectAll();
-  updateToMultiCopyToBackpack();
+  updateToMultiCopyToBackpack(backpackOnlySelected);
 };

--- a/test-e2e/actions/multiselect/workspace/backpack.spec.ts
+++ b/test-e2e/actions/multiselect/workspace/backpack.spec.ts
@@ -1,0 +1,247 @@
+import { expect } from "@playwright/test";
+import {
+  getBlock,
+  loadBlocks,
+  openBackpack,
+  test,
+} from "../../../test";
+
+const blockStructure = [
+  {
+    type: "controls_if",
+    id: "block-top",
+    inputs: {
+      DO0: {
+        block: { type: "controls_if", id: "block-input" }
+      }
+    },
+    next: {
+      block: {
+        type: "controls_if",
+        id: "block-next",
+        next: {
+          block: { type: "controls_if", id: "block-bottom" }
+        }
+      }
+    }
+  }
+];
+
+/**
+ * Toggles the backpackOnlySelected_ flag at runtime
+ */
+const setBackpackOnlySelected = async (page: any, value: boolean) => {
+  await page.evaluate((val: boolean) => {
+    const multiselectPlugin = (window as any).multiselectPlugin;
+    multiselectPlugin.backpackOnlySelected_ = true;
+
+    multiselectPlugin.dispose(false);
+    multiselectPlugin.init({
+        multiSelectKeys: ['Shift'],
+        multiselectIcon: {
+            hideIcon: false,
+            weight: 3,
+            enabledIcon: 'media/select.svg',
+            disabledIcon: 'media/unselect.svg',
+        },
+        multiselectCopyPaste: {
+            crossTab: true,
+            menu: true,
+        },
+        backpackOnlySelected: val,
+    });
+  }, value);
+}
+
+test.describe("backpackOnlySelected_ OFF", () => {
+  test.beforeEach(async ({ page, act }) => {
+    await setBackpackOnlySelected(page, false);
+    await act(loadBlocks(page, blockStructure));
+  });
+
+  test("select top block backpacks full chain", async ({ page, act }) => {
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" })).toBeVisible();
+    
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" }).click());
+
+    await openBackpack(page);
+    await getBlock(page, { type: "controls_if", workspace: "backpack" });
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(1);
+  });
+
+  test("select top + input backpacks full chain", async ({ page, act }) => {
+    await act(page.keyboard.down("Shift"));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-input" })).centerTop));
+    await act(page.keyboard.up("Shift"));
+
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" }).click());
+
+    await openBackpack(page);
+    await getBlock(page, { type: "controls_if", workspace: "backpack" });
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(1);
+  });
+
+  test("select top + next backpacks 2 chains", async ({ page, act }) => {
+    await act(page.keyboard.down("Shift"));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-next" })).centerTop));
+    await act(page.keyboard.up("Shift"));
+
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack (2)" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack (2)" }).click());
+
+    await openBackpack(page);
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(2);
+  });
+
+  test("select top + bottom backpacks 2 chains", async ({ page, act }) => {
+    await act(page.keyboard.down("Shift"));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-bottom" })).centerTop));
+    await act(page.keyboard.up("Shift"));
+
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack (2)" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack (2)" }).click());
+
+    await openBackpack(page);
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(2);
+  });
+});
+
+test.describe("backpackOnlySelected_ ON", () => {
+  test.beforeEach(async ({ page, act }) => {
+    await setBackpackOnlySelected(page, true);
+    await act(loadBlocks(page, blockStructure));
+  });
+
+  test("select top block backpacks selected + inputs only", async ({ page, act }) => {
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" }).click());
+
+    await openBackpack(page);
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(1);
+    
+    await getBlock(page, { type: "controls_if", workspace: "backpack" });
+  });
+
+  test("select top + input backpacks selected + inputs only", async ({ page, act }) => {
+    await act(page.keyboard.down("Shift"));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-input" })).centerTop));
+    await act(page.keyboard.up("Shift"));
+
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" }).click());
+
+    await openBackpack(page);
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(1);
+  });
+
+  test("select top + next backpacks as single unit with inputs", async ({ page, act }) => {
+    await act(page.keyboard.down("Shift"));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-next" })).centerTop));
+    await act(page.keyboard.up("Shift"));
+
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack" }).click());
+
+    await openBackpack(page);
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(1);
+  });
+
+  test("select top + bottom backpacks 2 separate units", async ({ page, act }) => {
+    await act(page.keyboard.down("Shift"));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop));
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-bottom" })).centerTop));
+    await act(page.keyboard.up("Shift"));
+
+    await act(page.mouse.click(...(await getBlock(page, { id: "block-top" })).centerTop, { button: "right" }));
+    await expect(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack (2)" })).toBeVisible();
+    await act(page.getByRole("menuitem", { exact: true, name: "Copy to Backpack (2)" }).click());
+
+    await openBackpack(page);
+    
+    const topBlocks = await page.evaluate(() => {
+        const ws = (window as any).Blockly.getMainWorkspace();
+        const backpack = ws.getComponentManager().getComponent("backpack");
+        if (!backpack) return 0;
+        const flyout = backpack.getFlyout();
+        if (!flyout) return 0;
+        return flyout.getWorkspace().getTopBlocks().length;
+    });
+    expect(topBlocks).toBe(2);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,7 @@ function createWorkspace(blocklyDiv, options) {
 
   // Initialize multiselect plugin.
   const multiselectPlugin = new Multiselect(workspace);
+  window.multiselectPlugin = multiselectPlugin;
   multiselectPlugin.init(options);
 
   return workspace;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #137

### Proposed Changes

Added `backpackOnlySelected` option (by default false). With option enabled:
- Backpacks sequentially selected blocks as a single unit
- Does not backpack "NEXT" items that are not in selection (does add INPUTs tho)
- If selected blocks are not connected, then they are saved as separate units
- Shows correct number of saved units in "Copy to backpack" context menu displayed text
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

This seems like a more reasonable behaviour for backpacking
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added tests to verify behaviour when option is OFF and ON

I had to modify `index.js` file to expose `window.multiselectPlugin`
<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

I have updated README.md with option description
<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I think this could be very well `true` by default

I did not update dragging block onto backpack behaviour as it seems reasonable to save entire chain, since you *do* drag entire chain

Code `cleanFlyoutInfo` is taken from backpack plugin repository. We can call this as a method on backpack directly in Blockly 12. Unfortunately, it's not available in Blockly 11 version
<!-- Anything else we should know? -->
